### PR TITLE
BLUE-29: feat: check balance before staking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3489,15 +3489,18 @@ const shardusSetup = (): void => {
             operatorEVMAccount.operatorAccountInfo
           )
         }
+        const txFeeUsd = BigInt(ShardeumFlags.constantTxFeeUsd)
+        const txFee = scaleByStabilityFactor(txFeeUsd, AccountsStorage.cachedNetworkAccount)
+        const totalAmountToDeduct = stakeCoinsTx.stake + txFee
+        if (operatorEVMAccount.account.balance < totalAmountToDeduct) {
+          throw new Error('Operator account does not have enough balance to stake')
+        }
         operatorEVMAccount.operatorAccountInfo.stake += stakeCoinsTx.stake
         operatorEVMAccount.operatorAccountInfo.nominee = stakeCoinsTx.nominee
         if (operatorEVMAccount.operatorAccountInfo.certExp == null)
           operatorEVMAccount.operatorAccountInfo.certExp = 0
         fixDeserializedWrappedEVMAccount(operatorEVMAccount)
 
-        const txFeeUsd = BigInt(ShardeumFlags.constantTxFeeUsd)
-        const txFee = scaleByStabilityFactor(txFeeUsd, AccountsStorage.cachedNetworkAccount)
-        const totalAmountToDeduct = stakeCoinsTx.stake + txFee
         operatorEVMAccount.account.balance = operatorEVMAccount.account.balance - totalAmountToDeduct
         operatorEVMAccount.account.nonce = operatorEVMAccount.account.nonce + BigInt(1)
 


### PR DESCRIPTION
https://linear.app/shm/issue/BLUE-29/bug-in-apply-function-stake-subtracted-without-verifying

Summary: Add a check in apply() function for adding a stake where we first verify the funds available in the account before deducting the stake