### PR TITLE
Link dockerfile to image in GHCR

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -10,6 +10,9 @@
 # Node.js LTS 12.x.x from Docker Hub
 FROM node:18.16.1
 
+# Link this Dockerfile to the image in the GHCR
+LABEL "org.opencontainers.image.source"="https://github.com/shardeum/shardeum"
+
 # Create app directory
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Adding this label should link this dockerfile to the package in the github container registry https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys