### PR TITLE
Gold 93: Fix timestamp bigint floating point error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1111,6 +1111,10 @@ const configShardusEndpoints = (): void => {
 
   shardus.registerExternalPost('inject', externalApiMiddleware, async (req, res) => {
     const tx = req.body
+    // if timestamp is a float, round it down to nearest millisecond
+    if (tx.timestamp && typeof tx.timestamp === 'number') {
+      tx.timestamp = Math.floor(tx.timestamp)
+    }
     const appData = null
     const id = shardus.getNodeId()
     const isInRotationBonds = shardus.isNodeInRotationBounds(id)

--- a/src/setup/helpers.ts
+++ b/src/setup/helpers.ts
@@ -89,10 +89,7 @@ export function getInjectedOrGeneratedTimestamp(timestampedTx): number {
     }
   }
   // if timestamp is a float, round it down to nearest millisecond
-  if (txnTimestamp && typeof txnTimestamp === 'number') {
-    txnTimestamp = Math.floor(txnTimestamp)
-  }
-  return txnTimestamp
+  return Math.floor(txnTimestamp)
 }
 
 /**

--- a/src/setup/helpers.ts
+++ b/src/setup/helpers.ts
@@ -88,6 +88,10 @@ export function getInjectedOrGeneratedTimestamp(timestampedTx): number {
       console.log(`Timestamp ${txnTimestamp} is extracted from the injected tx.`)
     }
   }
+  // if timestamp is a float, round it down to nearest millisecond
+  if (txnTimestamp && typeof txnTimestamp === 'number') {
+    txnTimestamp = Math.floor(txnTimestamp)
+  }
   return txnTimestamp
 }
 


### PR DESCRIPTION
https://linear.app/shm/issue/GOLD-93/serialisation-error-in-long-running-network

Summary: BigInt serialization error was occurring because the injected transaction via JSON-RPC was not rounded down to the nearest millisecond. This change make sure that timestamp is rounded off before serialization happens.