### PR TITLE
BLUE-54: Penalty History & Validation Fixes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2628,6 +2628,7 @@ const createNodeAccount2 = (accountId: string): NodeAccount2 => {
       totalPenalty: BigInt(0),
       history: [],
       penaltyHistory: [],
+      lastPenaltyTime: 0,
       isShardeumRun: false,
     },
     // rewarded: false // To be compatible with v1.1.2 nodes, commented out for now.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2627,6 +2627,7 @@ const createNodeAccount2 = (accountId: string): NodeAccount2 => {
       totalReward: BigInt(0),
       totalPenalty: BigInt(0),
       history: [],
+      penaltyHistory: [],
       isShardeumRun: false,
     },
     // rewarded: false // To be compatible with v1.1.2 nodes, commented out for now.

--- a/src/shardeum/shardeumTypes.ts
+++ b/src/shardeum/shardeumTypes.ts
@@ -209,7 +209,8 @@ export interface PenaltyTX extends InternalTxBase {
   reportedNodePublickKey: string
   operatorEVMAddress: string
   violationType: ViolationType
-  violationData: LeftNetworkEarlyViolationData // will add more types later
+  violationData: LeftNetworkEarlyViolationData | SyncingTimeoutViolationData | NodeRefutedViolationData
+  // will add more types later
   timestamp: number
   sign: ShardusTypes.Sign
 }
@@ -369,7 +370,8 @@ export interface NodeAccountStats {
   totalPenalty: bigint
   //push begin and end times when rewarded
   history: { b: number; e: number }[]
-
+  lastPenaltyTime: number
+  penaltyHistory: { type: ViolationType; amount: bigint; timestamp: number }[]
   //set when first staked
   isShardeumRun: boolean
 }

--- a/src/tx/penalty/transaction.ts
+++ b/src/tx/penalty/transaction.ts
@@ -324,7 +324,7 @@ export async function applyPenaltyTX(
 
   const { isProcessed, eventTime } = isProcessedPenaltyTx(tx, nodeAccount)
   if (isProcessed) {
-    /* prettier-ignore */ if (logFlags.dapp_verbose) console.log(`Duplicate penaltyTX: , TxId: ${txId}, reportedNode ${tx.reportedNodePublickKey}, ${{lastPenaltyTime: nodeAccount.nodeAccountStats.lastPenaltyTime, eventTime}}`)
+    /* prettier-ignore */ if (logFlags.dapp_verbose) console.log(`Processed penaltyTX: , TxId: ${txId}, reportedNode ${tx.reportedNodePublickKey}, ${{lastPenaltyTime: nodeAccount.nodeAccountStats.lastPenaltyTime, eventTime}}`)
     shardus.applyResponseSetFailed(
       applyResponse,
       `applyPenaltyTX failed isProcessedPenaltyTx reportedNode: ${tx.reportedNodePublickKey}`

--- a/src/tx/penalty/transaction.ts
+++ b/src/tx/penalty/transaction.ts
@@ -131,31 +131,31 @@ function recordPenaltyTX(txId: string, tx: PenaltyTX): void {
 /**
  * Compares the event timestamp of the penalty tx with the timestamp of the last saved penalty tx
  */
-function isDuplicatePenaltyTx(
+function isProcessedPenaltyTx(
   tx: PenaltyTX,
   nodeAccount: NodeAccount2
-): { isDuplicate: boolean; eventTime: number } {
+): { isProcessed: boolean; eventTime: number } {
   switch (tx.violationType) {
     case ViolationType.LeftNetworkEarly:
       return {
-        isDuplicate:
-          nodeAccount.nodeAccountStats.lastPenaltyTime ===
+        isProcessed:
+          nodeAccount.nodeAccountStats.lastPenaltyTime >=
           (tx.violationData as LeftNetworkEarlyViolationData).nodeDroppedTime,
         eventTime: (tx.violationData as LeftNetworkEarlyViolationData).nodeDroppedTime,
       }
 
     case ViolationType.NodeRefuted:
       return {
-        isDuplicate:
-          nodeAccount.nodeAccountStats.lastPenaltyTime ===
+        isProcessed:
+          nodeAccount.nodeAccountStats.lastPenaltyTime >=
           (tx.violationData as NodeRefutedViolationData).nodeRefutedTime,
         eventTime: (tx.violationData as NodeRefutedViolationData).nodeRefutedTime,
       }
 
     case ViolationType.SyncingTooLong:
       return {
-        isDuplicate:
-          nodeAccount.nodeAccountStats.lastPenaltyTime ===
+        isProcessed:
+          nodeAccount.nodeAccountStats.lastPenaltyTime >=
           (tx.violationData as SyncingTimeoutViolationData).nodeDroppedTime,
         eventTime: (tx.violationData as SyncingTimeoutViolationData).nodeDroppedTime,
       }
@@ -322,12 +322,12 @@ export async function applyPenaltyTX(
     operatorAccount = wrappedStates[operatorShardusAddress].data as WrappedEVMAccount
   }
 
-  const { isDuplicate, eventTime } = isDuplicatePenaltyTx(tx, nodeAccount)
-  if (isDuplicate) {
+  const { isProcessed, eventTime } = isProcessedPenaltyTx(tx, nodeAccount)
+  if (isProcessed) {
     /* prettier-ignore */ if (logFlags.dapp_verbose) console.log(`Duplicate penaltyTX: , TxId: ${txId}, reportedNode ${tx.reportedNodePublickKey}, ${{lastPenaltyTime: nodeAccount.nodeAccountStats.lastPenaltyTime, eventTime}}`)
     shardus.applyResponseSetFailed(
       applyResponse,
-      `applyPenaltyTX failed isDuplicatePenaltyTX reportedNode: ${tx.reportedNodePublickKey}`
+      `applyPenaltyTX failed isProcessedPenaltyTx reportedNode: ${tx.reportedNodePublickKey}`
     )
     return
   }
@@ -340,9 +340,8 @@ export async function applyPenaltyTX(
     amount: penaltyAmount,
     timestamp: eventTime,
   })
-  if (tx.violationType === ViolationType.LeftNetworkEarly) {
-    nodeAccount.rewardEndTime =
-      (tx.violationData as LeftNetworkEarlyViolationData)?.nodeDroppedTime || Math.floor(tx.timestamp / 1000)
+  if (tx.violationType === ViolationType.LeftNetworkEarly && nodeAccount.rewardStartTime > 0) {
+    nodeAccount.rewardEndTime = (tx.violationData as LeftNetworkEarlyViolationData)?.nodeDroppedTime
     nodeAccount.nodeAccountStats.history.push({
       b: nodeAccount.rewardStartTime,
       e: nodeAccount.rewardEndTime,


### PR DESCRIPTION
### Summary
This PR:
1. Adds a **`penaltyHistory`** field to the nodeAccounts property to keep a record of all the penalties by a validator.
2. Adds a validation check (**`isDuplicatePenaltyTx`**) to avoid publishing a duplicate Penalty tx.

#### [Linear Task](https://linear.app/shm/issue/BLUE-54/bad-history-for-penalty)

### Testing Notes
Please make sure that you enable the **`enableLeftNetworkEarlySlashing`** flag in the **`shardeumFlags.ts`** to allow penalty txs for lost/apop/left early nodes.