### PR TITLE
BLUE-54 + BLUE-84: Penalty history added, refactoring and recordPenaltyTx fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6785,15 +6785,7 @@ const shardusSetup = (): void => {
         }
         nestedCountersInstance.countEvent('shardeum-staking', `node-sync-timeout: injectPenaltyTx`)
 
-        // Limit the nodes that send this to the 5 closest to the node id
-        const closestNodes = shardus.getClosestNodes(data.nodeId, 5)
-        const ourId = shardus.getNodeId()
-        for (const id of closestNodes) {
-          if (id === ourId) {
-            const result = await PenaltyTx.injectPenaltyTX(shardus, data, violationData)
-            /* prettier-ignore */ if (logFlags.dapp_verbose) console.log('INJECTED_PENALTY_TX', result)
-          }
-        }
+        await PenaltyTx.injectPenaltyTX(shardus, data, violationData)
       } else if (
         eventType === 'node-refuted' &&
         ShardeumFlags.enableNodeSlashing === true &&
@@ -6814,15 +6806,7 @@ const shardusSetup = (): void => {
           }
           nestedCountersInstance.countEvent('shardeum-staking', `node-refuted: injectPenaltyTx`)
 
-          // Limit the nodes that send this to the 5 closest to the node id
-          const closestNodes = shardus.getClosestNodes(data.nodeId, 5)
-          const ourId = shardus.getNodeId()
-          for (const id of closestNodes) {
-            if (id === ourId) {
-              const result = await PenaltyTx.injectPenaltyTX(shardus, data, violationData)
-              /* prettier-ignore */ if (logFlags.dapp_verbose) console.log('INJECTED_PENALTY_TX', result)
-            }
-          }
+          await PenaltyTx.injectPenaltyTX(shardus, data, violationData)
         } else {
           nestedCountersInstance.countEvent('shardeum-staking', `node-refuted: event skipped`)
           /* prettier-ignore */ if (logFlags.dapp_verbose) console.log(`Shardeum node-refuted event skipped`, data, nodeRefutedCycle)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2633,6 +2633,7 @@ const createNodeAccount2 = (accountId: string): NodeAccount2 => {
       totalPenalty: BigInt(0),
       history: [],
       penaltyHistory: [],
+      lastPenaltyTime: 0,
       isShardeumRun: false,
     },
     // rewarded: false // To be compatible with v1.1.2 nodes, commented out for now.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6769,15 +6769,7 @@ const shardusSetup = (): void => {
           }
           nestedCountersInstance.countEvent('shardeum-staking', `node-left-early: injectPenaltyTx`)
 
-          // Limit the nodes that send this to the 5 closest to the node id
-          const closestNodes = shardus.getClosestNodes(data.nodeId, 5)
-          const ourId = shardus.getNodeId()
-          for (const id of closestNodes) {
-            if (id === ourId) {
-              const result = await PenaltyTx.injectPenaltyTX(shardus, data, violationData)
-              /* prettier-ignore */ if (logFlags.dapp_verbose) console.log('INJECTED_PENALTY_TX', result)
-            }
-          }
+          await PenaltyTx.injectPenaltyTX(shardus, data, violationData)
         } else {
           nestedCountersInstance.countEvent('shardeum-staking', `node-left-early: event skipped`)
           /* prettier-ignore */ if (logFlags.dapp_verbose) console.log(`Shardeum node-left-early event skipped`, data, nodeLostCycle, nodeDroppedCycle)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2617,7 +2617,7 @@ const createNetworkAccount = async (
 }
 
 const createNodeAccount2 = (accountId: string): NodeAccount2 => {
-  const nodeAccount = {
+  const nodeAccount: NodeAccount2 = {
     id: accountId,
     hash: '',
     timestamp: 0,
@@ -2636,9 +2636,8 @@ const createNodeAccount2 = (accountId: string): NodeAccount2 => {
       lastPenaltyTime: 0,
       isShardeumRun: false,
     },
-    // rewarded: false // To be compatible with v1.1.2 nodes, commented out for now.
-  } as NodeAccount2
-  if (ShardeumFlags.rewardedFalseInInitRewardTx) nodeAccount.rewarded = false
+    rewarded: false,
+  }
   WrappedEVMAccountFunctions.updateEthAccountHash(nodeAccount)
   return nodeAccount
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2632,6 +2632,7 @@ const createNodeAccount2 = (accountId: string): NodeAccount2 => {
       totalReward: BigInt(0),
       totalPenalty: BigInt(0),
       history: [],
+      penaltyHistory: [],
       isShardeumRun: false,
     },
     // rewarded: false // To be compatible with v1.1.2 nodes, commented out for now.

--- a/src/shardeum/shardeumTypes.ts
+++ b/src/shardeum/shardeumTypes.ts
@@ -209,7 +209,8 @@ export interface PenaltyTX extends InternalTxBase {
   reportedNodePublickKey: string
   operatorEVMAddress: string
   violationType: ViolationType
-  violationData: LeftNetworkEarlyViolationData // will add more types later
+  violationData: LeftNetworkEarlyViolationData | SyncingTimeoutViolationData | NodeRefutedViolationData
+  // will add more types later
   timestamp: number
   sign: ShardusTypes.Sign
 }
@@ -369,7 +370,8 @@ export interface NodeAccountStats {
   totalPenalty: bigint
   //push begin and end times when rewarded
   history: { b: number; e: number }[]
-
+  lastPenaltyTime: number
+  penaltyHistory: { type: ViolationType; amount: bigint; timestamp: number }[]
   //set when first staked
   isShardeumRun: boolean
 }

--- a/src/tx/penalty/transaction.ts
+++ b/src/tx/penalty/transaction.ts
@@ -87,7 +87,10 @@ export async function injectPenaltyTX(
   recordPenaltyTX(txId, signedTx)
 
   // Limit the nodes that send this to the 5 closest to the node id
-  const closestNodes = shardus.getClosestNodes(eventData.nodeId, 5)
+  const closestNodes = shardus.getClosestNodes(
+    eventData.publicKey,
+    ShardeumFlags.numberOfNodesToInjectPenaltyTx
+  )
   const ourId = shardus.getNodeId()
   for (const id of closestNodes) {
     if (id === ourId) {

--- a/src/tx/penalty/transaction.ts
+++ b/src/tx/penalty/transaction.ts
@@ -102,6 +102,43 @@ function recordPenaltyTX(txId: string, tx: PenaltyTX): void {
   }
 }
 
+/**
+ * Compares the event timestamp of the penalty tx with the timestamp of the last saved penalty tx
+ */
+function isDuplicatePenaltyTx(
+  tx: PenaltyTX,
+  nodeAccount: NodeAccount2
+): { isDuplicate: boolean; eventTime: number } {
+  switch (tx.violationType) {
+    case ViolationType.LeftNetworkEarly:
+      return {
+        isDuplicate:
+          nodeAccount.nodeAccountStats.lastPenaltyTime ===
+          (tx.violationData as LeftNetworkEarlyViolationData).nodeDroppedTime,
+        eventTime: (tx.violationData as LeftNetworkEarlyViolationData).nodeDroppedTime,
+      }
+
+    case ViolationType.NodeRefuted:
+      return {
+        isDuplicate:
+          nodeAccount.nodeAccountStats.lastPenaltyTime ===
+          (tx.violationData as NodeRefutedViolationData).nodeRefutedTime,
+        eventTime: (tx.violationData as NodeRefutedViolationData).nodeRefutedTime,
+      }
+
+    case ViolationType.SyncingTooLong:
+      return {
+        isDuplicate:
+          nodeAccount.nodeAccountStats.lastPenaltyTime ===
+          (tx.violationData as SyncingTimeoutViolationData).nodeDroppedTime,
+        eventTime: (tx.violationData as SyncingTimeoutViolationData).nodeDroppedTime,
+      }
+
+    default:
+      throw new Error(`Unknown Violation type: , ${tx.violationType}`)
+  }
+}
+
 export function clearOldPenaltyTxs(shardus: Shardus): void {
   let deleteCount = 0
   /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-penalty', `clearOldPenaltyTxs mapSize:${penaltyTxsMap.size}`)
@@ -259,17 +296,39 @@ export async function applyPenaltyTX(
     operatorAccount = wrappedStates[operatorShardusAddress].data as WrappedEVMAccount
   }
 
-
+  const { isDuplicate, eventTime } = isDuplicatePenaltyTx(tx, nodeAccount)
+  if (isDuplicate) {
+    /* prettier-ignore */ if (logFlags.dapp_verbose) console.log(`Duplicate penaltyTX: , TxId: ${txId}, reportedNode ${tx.reportedNodePublickKey}, ${{lastPenaltyTime: nodeAccount.nodeAccountStats.lastPenaltyTime, eventTime}}`)
+    shardus.applyResponseSetFailed(
+      applyResponse,
+      `applyPenaltyTX failed isDuplicatePenaltyTX reportedNode: ${tx.reportedNodePublickKey}`
+    )
+    return
+  }
 
   //TODO should we check if it was already penalized?
   const penaltyAmount = getPenaltyForViolation(tx, nodeAccount.stakeLock)
   applyPenalty(nodeAccount, operatorAccount, penaltyAmount)
+  nodeAccount.nodeAccountStats.penaltyHistory.push({
+    type: tx.violationType,
+    amount: penaltyAmount,
+    timestamp: eventTime,
+  })
   if (tx.violationType === ViolationType.LeftNetworkEarly) {
-    nodeAccount.rewardEndTime = tx.violationData?.nodeDroppedTime || Math.floor(tx.timestamp / 1000)
-    nodeAccount.nodeAccountStats.history.push({ b: nodeAccount.rewardStartTime, e: nodeAccount.rewardEndTime })
+    nodeAccount.rewardEndTime =
+      (tx.violationData as LeftNetworkEarlyViolationData)?.nodeDroppedTime || Math.floor(tx.timestamp / 1000)
+    nodeAccount.nodeAccountStats.history.push({
+      b: nodeAccount.rewardStartTime,
+      e: nodeAccount.rewardEndTime,
+    })
+    operatorAccount.operatorAccountInfo.operatorStats.history.push({
+      b: nodeAccount.rewardStartTime,
+      e: nodeAccount.rewardEndTime,
+    })
   }
 
   nodeAccount.timestamp = txTimestamp
+  nodeAccount.nodeAccountStats.lastPenaltyTime = eventTime
   operatorAccount.timestamp = txTimestamp
 
   const shardeumState = getApplyTXState(txId)

--- a/src/tx/penalty/transaction.ts
+++ b/src/tx/penalty/transaction.ts
@@ -86,32 +86,6 @@ export async function injectPenaltyTX(
   // store the unsignedTx to local map for later use
   recordPenaltyTX(txId, signedTx)
 
-  // inject the unsignedTx if we are lucky node
-  const consensusNodes = shardus.getConsenusGroupForAccount(signedTx.reportedNodePublickKey)
-  const consensusNodeIdsAndRanks: { nodeId: string; rank: bigint }[] = consensusNodes.map((n) => {
-    return {
-      nodeId: n.id,
-      rank: shardus.computeNodeRank(n.id, txId, signedTx.timestamp),
-    }
-  })
-  const sortedNodeIdsAndRanks = consensusNodeIdsAndRanks.sort((a, b): number => {
-    return b.rank > a.rank ? 1 : -1
-  })
-  const ourNodeId = shardus.getNodeId()
-
-  let isLuckyNode = false
-  for (let i = 0; i < ShardeumFlags.numberOfNodesToInjectPenaltyTx; i++) {
-    if (sortedNodeIdsAndRanks[i].nodeId === ourNodeId) {
-      isLuckyNode = true
-      break
-    }
-  }
-
-  if (!isLuckyNode) {
-    if (ShardeumFlags.VerboseLogs)
-      console.log(`injectPenaltyTX: not lucky node, skipping injection`, signedTx)
-    return
-  }
   // since we have to pick a future timestamp, we need to wait until it is time to submit the signedTx
   await sleep(waitTime)
 

--- a/src/tx/penalty/transaction.ts
+++ b/src/tx/penalty/transaction.ts
@@ -298,7 +298,7 @@ export async function applyPenaltyTX(
 
   const { isProcessed, eventTime } = isProcessedPenaltyTx(tx, nodeAccount)
   if (isProcessed) {
-    /* prettier-ignore */ if (logFlags.dapp_verbose) console.log(`Duplicate penaltyTX: , TxId: ${txId}, reportedNode ${tx.reportedNodePublickKey}, ${{lastPenaltyTime: nodeAccount.nodeAccountStats.lastPenaltyTime, eventTime}}`)
+    /* prettier-ignore */ if (logFlags.dapp_verbose) console.log(`Processed penaltyTX: , TxId: ${txId}, reportedNode ${tx.reportedNodePublickKey}, ${{lastPenaltyTime: nodeAccount.nodeAccountStats.lastPenaltyTime, eventTime}}`)
     shardus.applyResponseSetFailed(
       applyResponse,
       `applyPenaltyTX failed isProcessedPenaltyTx reportedNode: ${tx.reportedNodePublickKey}`


### PR DESCRIPTION
### Summary
This PR:
1. Adds penalty history associated properties, **`lastPenaltyTime`** and **`penaltyHistory`**.
2. Removes redundant code and adds a fix for **`recordPenaltyFix`**.

#### **Linear Tasks:** [BLUE-54](https://linear.app/shm/issue/BLUE-54) & [BLUE-84](https://linear.app/shm/issue/BLUE-84)

### Testing Notes
Please make sure that you enable the **`enableLeftNetworkEarlySlashing`** flag in the **`shardeumFlags.ts`** to allow penalty txs for lost/apop/left early nodes.