### PR TITLE
Update NetworkAccount serialization to include appData field

### DIFF
--- a/scripts/generateWallet.js
+++ b/scripts/generateWallet.js
@@ -1,0 +1,8 @@
+const crypto = require('@shardus/crypto-utils');
+
+// Generate a random keypair
+const keypair = crypto.generateKeypair();
+
+// Print the generated keypair to the console
+console.log('Public Key:', keypair.publicKey);
+console.log('Secret Key:', keypair.secretKey);

--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -120,6 +120,7 @@ interface ShardeumFlags {
   internalTxTimestampFix: boolean
   debugExtraNonceLookup: boolean
   cleanStaleShardeumStateMap: boolean
+  beta1_11_2: boolean
 }
 
 export const ShardeumFlags: ShardeumFlags = {
@@ -276,6 +277,7 @@ export const ShardeumFlags: ShardeumFlags = {
 
   //1.1.2 migration
   cleanStaleShardeumStateMap: false,
+  beta1_11_2: true,
 }
 
 export function updateShardeumFlag(key: string, value: string | number | boolean): void {

--- a/src/shardeum/shardeumTypes.ts
+++ b/src/shardeum/shardeumTypes.ts
@@ -309,6 +309,8 @@ export interface NetworkAccount extends BaseAccount {
   listOfChanges: Array<{
     cycle: number
     change: Change
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    appData: any
   }>
   next: NetworkParameters | object //todo potentially improve this, but will need functional changes
   hash: string

--- a/src/types/NetworkAccount.ts
+++ b/src/types/NetworkAccount.ts
@@ -3,8 +3,13 @@ import { Change, NetworkParameters } from '../shardeum/shardeumTypes'
 import { BaseAccount, deserializeBaseAccount, serializeBaseAccount } from './BaseAccount'
 import { TypeIdentifierEnum } from './enum/TypeIdentifierEnum'
 import { Utils } from '@shardus/types'
+import { ShardeumFlags } from '../shardeum/shardeumFlags'
 
 const cNetworkAccountVersion = 1
+
+// Delete this and the corresponding flag post upgrade to 1.11.2
+const Beta1_11_2NetworkAccountJson =
+  '{"accountType":5,"current":{"activeVersion":"1.11.0","archiver":{"activeVersion":"3.4.12","latestVersion":"3.4.12","minVersion":"3.4.12"},"certCycleDuration":30,"description":"These are the initial network parameters Shardeum started with","latestVersion":"1.11.2","maintenanceFee":0,"maintenanceInterval":86400000,"minVersion":"1.11.2","nodePenaltyUsd":{"dataType":"bi","value":"8ac7230489e80000"},"nodeRewardAmountUsd":{"dataType":"bi","value":"de0b6b3a7640000"},"nodeRewardInterval":3600000,"stabilityScaleDiv":1000,"stabilityScaleMul":1000,"stakeRequiredUsd":{"dataType":"bi","value":"8ac7230489e80000"},"title":"Initial parameters","txPause":false},"hash":"a8db05a4e6afe56b8c70cb3bc74f38531444967671daa353efa70d871132f9f9","id":"1000000000000000000000000000000000000000000000000000000000000001","listOfChanges":[{"appData":{"latestVersion":"1.11.2"},"change":{},"cycle":9363},{"appData":{"latestVersion":"1.11.2"},"change":{},"cycle":9380},{"appData":{"minVersion":"1.11.2"},"change":{},"cycle":9381},{"appData":{"minVersion":"1.11.2"},"change":{},"cycle":9382},{"appData":{"latestVersion":"1.11.2"},"change":{},"cycle":9531}],"next":{},"timestamp":1719569447484}'
 
 export interface NetworkAccount extends BaseAccount {
   id: string
@@ -48,6 +53,10 @@ export function serializeNetworkAccount(stream: VectorBufferStream, obj: Network
 }
 
 export function deserializeNetworkAccount(stream: VectorBufferStream): NetworkAccount {
+  if (ShardeumFlags.beta1_11_2) {
+    return Utils.safeJsonParse(Beta1_11_2NetworkAccountJson) as NetworkAccount
+  }
+
   const version = stream.readUInt8()
   if (version > cNetworkAccountVersion) {
     throw new Error('NetworkAccount version mismatch')

--- a/src/types/NetworkAccount.ts
+++ b/src/types/NetworkAccount.ts
@@ -12,8 +12,10 @@ export interface NetworkAccount extends BaseAccount {
   listOfChanges: Array<{
     cycle: number
     change: Change
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    appData: any
   }>
-  next
+  next: NetworkParameters | object
   hash: string
   timestamp: number
 }
@@ -37,6 +39,8 @@ export function serializeNetworkAccount(stream: VectorBufferStream, obj: Network
     stream.writeUInt32(changeObj.cycle)
     const changeJson = Utils.safeStringify(changeObj.change)
     stream.writeString(changeJson)
+    const appDataJson = Utils.safeStringify(changeObj.appData)
+    stream.writeString(appDataJson)
   }
 
   stream.writeString(obj.hash)
@@ -60,7 +64,8 @@ export function deserializeNetworkAccount(stream: VectorBufferStream): NetworkAc
   for (let i = 0; i < changesCount; i++) {
     const cycle = stream.readUInt32()
     const change = Utils.safeJsonParse(stream.readString()) as Change
-    listOfChanges.push({ cycle, change })
+    const appData = Utils.safeJsonParse(stream.readString())
+    listOfChanges.push({ cycle, change, appData })
   }
 
   const hash = stream.readString()

--- a/src/versioning/index.ts
+++ b/src/versioning/index.ts
@@ -17,7 +17,7 @@ const appliedMigrations = new Set<string>()
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const onActiveVersionChange = async (newActiveVersion: string) => {
   // For future migrations, add a file under ./migrations and add the version here
-  const migrations = ['1.9.1', '1.10.2', '1.11.2']
+  const migrations = ['1.9.1', '1.10.2', '1.11.2', '1.11.3']
 
   for (let index = 0; index < migrations.length; index++) {
     const migrationVersion = migrations[index] // eslint-disable-line security/detect-object-injection

--- a/src/versioning/migrations/1.11.3.ts
+++ b/src/versioning/migrations/1.11.3.ts
@@ -1,0 +1,17 @@
+import { nestedCountersInstance } from '@shardus/core'
+import { ShardeumFlags } from '../../shardeum/shardeumFlags'
+import { Migration } from '../types'
+
+// This has been baked into settings and is not needed, but the goal is to keep one migration as
+// an example for when we need to migrate again.
+
+export const migrate: Migration = async () => {
+  console.log('migrate 1.11.3')
+  nestedCountersInstance.countEvent('migrate', 'calling migrate 1.11.3')
+
+  // this will disable the one time beta flag for 1.11.2
+  ShardeumFlags.beta1_11_2 = false
+}
+
+//WARNING if you add a new one of these migration files you must add it to the migrations list in
+// src/versioning/index.ts

--- a/test/ut/src/types/NetworkAccount.test.ts
+++ b/test/ut/src/types/NetworkAccount.test.ts
@@ -1,0 +1,36 @@
+import { VectorBufferStream } from '@shardus/core'
+import { Utils } from '@shardus/types'
+import {
+  NetworkAccount,
+  deserializeNetworkAccount,
+  serializeNetworkAccount,
+} from '../../../../src/types/NetworkAccount'
+import { TypeIdentifierEnum } from '../../../../src/types/enum/TypeIdentifierEnum'
+import { AccountType } from '../../../../src/shardeum/shardeumTypes'
+
+describe('NetworkAccount Serialization', () => {
+  test('should serialize with root true', () => {
+    const obj: NetworkAccount = {
+      accountType: AccountType.NetworkAccount,
+      id: 'test',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      current: { test: 'test' } as any,
+      listOfChanges: [{ cycle: 1, change: { test: 'test' }, appData: { test: 'test' } }],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      next: { test: 'test' } as any,
+      hash: 'test',
+      timestamp: 1,
+    }
+    const stream = new VectorBufferStream(0)
+    serializeNetworkAccount(stream, obj, true)
+
+    stream.position = 0
+
+    const type = stream.readUInt16()
+    expect(type).toEqual(TypeIdentifierEnum.cNetworkAccount)
+    const deserialised = deserializeNetworkAccount(stream)
+
+    expect(deserialised).toEqual(obj)
+    expect(Utils.safeStringify(deserialised)).toEqual(Utils.safeStringify(obj))
+  })
+})


### PR DESCRIPTION
This pull request updates the serialization of the NetworkAccount type to include the appData field. Previously, the appData field was not included in the serialization, causing data loss when deserializing NetworkAccount objects. This update ensures that the appData field is properly serialized and deserialized, preserving the integrity of the NetworkAccount objects.