### PR TITLE
Adding nonce to network account

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2509,6 +2509,7 @@ async function applyInternalTx(
       const networkAccountCopy = wrappedStates[networkAccount]
       networkAccountCopy.data.timestamp = txTimestamp
       networkAccountCopy.data.listOfChanges.push(internalTx.change)
+      networkAccountCopy.data.nonce = BigInt(networkAccountCopy.data.nonce) + BigInt(1)
       const wrappedChangedAccount = WrappedEVMAccountFunctions._shardusWrappedAccount(networkAccountCopy.data)
       shardus.applyResponseAddChangedAccount(
         applyResponse,
@@ -2520,6 +2521,7 @@ async function applyInternalTx(
     } else {
       network.timestamp = txTimestamp
       network.listOfChanges.push(internalTx.change)
+      network.nonce = BigInt(network.nonce) + BigInt(1)
     }
     if (ShardeumFlags.supportInternalTxReceipt) {
       createInternalTxReceipt(

--- a/src/index.ts
+++ b/src/index.ts
@@ -2801,6 +2801,8 @@ const createNetworkAccount = async (
     next: {},
     hash: '',
     timestamp: 0,
+    nonce: BigInt(0),
+    networkId: "",
   }
   account.hash = WrappedEVMAccountFunctions._calculateAccountHash(account)
   /* prettier-ignore */ if (logFlags.important_as_error) console.log('INITIAL_HASH: ', account.hash)

--- a/src/setup/validateTransaction.ts
+++ b/src/setup/validateTransaction.ts
@@ -27,6 +27,10 @@ export const validateTransaction =
         tx.internalTXType === InternalTXType.ChangeConfig ||
         internalTx.internalTXType === InternalTXType.ChangeNetworkParam
       ) {
+        const networkAccount = AccountsStorage.cachedNetworkAccount
+        if ((networkAccount.nonce - BigInt(1)) != BigInt(tx.nonce)) {
+          return { result: 'fail', reason: 'Invalid nonce' }
+        }
         const devPublicKeys = shardus.getDevPublicKeys()
         let isUserVerified = false
         for (const devPublicKey in devPublicKeys) {

--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -117,6 +117,7 @@ interface ShardeumFlags {
   internalTxTimestampFix: boolean
   debugExtraNonceLookup: boolean
   cleanStaleShardeumStateMap: boolean
+  beta1_11_2: boolean
   failedStakeReceipt: boolean // For stake/unstake TXs that fail the checks in apply(), create an EVM receipt marked as failed
 }
 
@@ -271,6 +272,7 @@ export const ShardeumFlags: ShardeumFlags = {
 
   //1.1.2 migration
   cleanStaleShardeumStateMap: false,
+  beta1_11_2: true,
 
   failedStakeReceipt: true,
 }

--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -117,7 +117,6 @@ interface ShardeumFlags {
   internalTxTimestampFix: boolean
   debugExtraNonceLookup: boolean
   cleanStaleShardeumStateMap: boolean
-  beta1_11_2: boolean
   failedStakeReceipt: boolean // For stake/unstake TXs that fail the checks in apply(), create an EVM receipt marked as failed
 }
 
@@ -272,7 +271,6 @@ export const ShardeumFlags: ShardeumFlags = {
 
   //1.1.2 migration
   cleanStaleShardeumStateMap: false,
-  beta1_11_2: true,
 
   failedStakeReceipt: true,
 }

--- a/src/shardeum/shardeumTypes.ts
+++ b/src/shardeum/shardeumTypes.ts
@@ -128,6 +128,8 @@ export interface InternalTx extends InternalTxBase {
   config?: string // change config
   nominee?: string // Node Account2
   nominator?: string // EVM Account (OperAcc)
+  nonce?: bigint // Network Account
+  networkId?: string // Network Account
   sign: ShardusTypes.Sign
 }
 
@@ -317,6 +319,8 @@ export interface NetworkAccount extends BaseAccount {
   next: NetworkParameters | object //todo potentially improve this, but will need functional changes
   hash: string
   timestamp: number
+  nonce: bigint
+  networkId: string
 }
 
 //type guard

--- a/src/types/NetworkAccount.ts
+++ b/src/types/NetworkAccount.ts
@@ -1,14 +1,10 @@
 import { VectorBufferStream } from '@shardus/core'
+import { Utils } from '@shardus/types'
 import { Change, NetworkParameters } from '../shardeum/shardeumTypes'
 import { BaseAccount, deserializeBaseAccount, serializeBaseAccount } from './BaseAccount'
 import { TypeIdentifierEnum } from './enum/TypeIdentifierEnum'
-import { Utils } from '@shardus/types'
-import { ShardeumFlags } from '../shardeum/shardeumFlags'
 
 const cNetworkAccountVersion = 1
-
-// Delete this and the corresponding flag post upgrade to 1.11.2
-// const Beta1_11_2NetworkAccountJson = '{"accountType":5,"current":{"activeVersion":"1.11.0","archiver":{"activeVersion":"3.4.12","latestVersion":"3.4.12","minVersion":"3.4.12"},"certCycleDuration":30,"description":"These are the initial network parameters Shardeum started with","latestVersion":"1.11.2","maintenanceFee":0,"maintenanceInterval":86400000,"minVersion":"1.11.2","nodePenaltyUsd":{"dataType":"bi","value":"8ac7230489e80000"},"nodeRewardAmountUsd":{"dataType":"bi","value":"de0b6b3a7640000"},"nodeRewardInterval":3600000,"stabilityScaleDiv":1000,"stabilityScaleMul":1000,"stakeRequiredUsd":{"dataType":"bi","value":"8ac7230489e80000"},"title":"Initial parameters","txPause":false},"hash":"6e60d839eabcb7578ae7a172288c3e2fc9c9fa8e7753e70534329f61561fb95d","id":"1000000000000000000000000000000000000000000000000000000000000001","listOfChanges":[{"appData":{"latestVersion":"1.11.2"},"change":{},"cycle":3807},{"appData":{"minVersion":"1.11.2"},"change":{},"cycle":3808},{"appData":{"minVersion":"1.11.2"},"change":{},"cycle":3809},{"appData":{"minVersion":"1.11.2"},"change":{},"cycle":3813}],"next":{},"timestamp":1719612186585}'
 
 export interface NetworkAccount extends BaseAccount {
   id: string
@@ -22,6 +18,8 @@ export interface NetworkAccount extends BaseAccount {
   next: NetworkParameters | object
   hash: string
   timestamp: number
+  nonce: bigint
+  networkId: string
 }
 
 export function serializeNetworkAccount(stream: VectorBufferStream, obj: NetworkAccount, root = false): void {
@@ -49,14 +47,11 @@ export function serializeNetworkAccount(stream: VectorBufferStream, obj: Network
 
   stream.writeString(obj.hash)
   stream.writeBigUInt64(BigInt(obj.timestamp))
+  stream.writeString(obj.nonce.toString())
+  stream.writeString(obj.networkId)
 }
 
 export function deserializeNetworkAccount(stream: VectorBufferStream): NetworkAccount {
-  if (ShardeumFlags.beta1_11_2) {
-    //Manualy disable this hack after 1.11.2
-  //  return Utils.safeJsonParse(Beta1_11_2NetworkAccountJson) as NetworkAccount
-  }
-
   const version = stream.readUInt8()
   if (version > cNetworkAccountVersion) {
     throw new Error('NetworkAccount version mismatch')
@@ -79,6 +74,8 @@ export function deserializeNetworkAccount(stream: VectorBufferStream): NetworkAc
 
   const hash = stream.readString()
   const timestamp = Number(stream.readBigUInt64())
+  const nonce = BigInt(stream.readString())
+  const networkId = stream.readString()
 
   return {
     ...baseAccount,
@@ -88,5 +85,7 @@ export function deserializeNetworkAccount(stream: VectorBufferStream): NetworkAc
     next,
     hash,
     timestamp,
+    nonce,
+    networkId,
   }
 }


### PR DESCRIPTION
https://linear.app/shm/issue/GOLD-194

This tasks is to add nonce and networkId to network account. These changes are to remove the possibility of replays once we enable network generated timestamps for internal transactions.