### PR TITLE
RED 204: drop `nodeReward` and `nodeInitReward` for testing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2409,6 +2409,15 @@ const configShardusNetworkTransactions = (): void => {
     async (txEntry: P2P.ServiceQueueTypes.AddNetworkTx<SignedNodeInitTxData>) => {
       const tx = txEntry.txData
       /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('Validating nodeInitReward applied', Utils.safeStringify(tx))
+      
+
+      if (ShardeumFlags.failNodeInitRewardApply) {
+        nestedCountersInstance.countEvent('shardeum-staking', `applyNodeInitReward fail for testing`)
+        console.log(`applyNodeInitReward failed for testing purposes; publicKey: ${tx.publicKey}`)
+        
+        return false
+      }
+      
       const shardusAddress = tx.publicKey?.toLowerCase()
       const account = await shardus.getLocalOrRemoteAccount(shardusAddress)
       if (!account) {

--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -119,6 +119,9 @@ interface ShardeumFlags {
   cleanStaleShardeumStateMap: boolean
   beta1_11_2: boolean
   failedStakeReceipt: boolean // For stake/unstake TXs that fail the checks in apply(), create an EVM receipt marked as failed
+  failNodeInitRewardApply: boolean
+  failClaimRewardApply: boolean
+  
 }
 
 export const ShardeumFlags: ShardeumFlags = {
@@ -275,6 +278,8 @@ export const ShardeumFlags: ShardeumFlags = {
   beta1_11_2: true,
 
   failedStakeReceipt: true,
+  failNodeInitRewardApply: false,
+  failClaimRewardApply: false,
 }
 
 export function updateShardeumFlag(key: string, value: string | number | boolean): void {

--- a/src/tx/claimReward.ts
+++ b/src/tx/claimReward.ts
@@ -279,6 +279,19 @@ export async function applyClaimRewardTx(
   mustUseAdminCert = false
 ): Promise<void> {
   if (ShardeumFlags.VerboseLogs) console.log(`Running applyClaimRewardTx`, tx, wrappedStates)
+
+
+  if (ShardeumFlags.failClaimRewardApply) {
+    nestedCountersInstance.countEvent('shardeum-staking', `applyClaimRewardTx fail for testing`)
+    console.log(`applyClaimRewardTx fail for testing; deactivatedNodeId: ${tx.deactivatedNodeId}`)
+    
+    shardus.applyResponseSetFailed(
+      applyResponse,
+      `applyClaimReward failed for testing purposes`
+    )
+    return
+  }
+
   // const isValidRequest = validateClaimRewardState(tx, wrappedStates, shardus, mustUseAdminCert)
   // if (isValidRequest.result === 'fail') {
   //   /* prettier-ignore */


### PR DESCRIPTION
https://linear.app/shm/issue/RED-204/design-tests-for-dropped-rewardpenalty-txs#heading-56c78cbf

Summary: add failNodeInitRewardApply and failClaimRewardApply to drop tx. Able to see count increment in txCount list when turned on.