### PR TITLE
BLUE-228: fix: subtracting slashing penalty twice

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4068,7 +4068,7 @@ const shardusSetup = (): void => {
 
           /* prettier-ignore */ if (logFlags.dapp_verbose) console.log('discarding staking rewards due to zero rewardEndTime')
         }
-        const newBalance = SafeBalance.addBigintBalance(currentBalance, stake + reward - penalty - txFee)
+        const newBalance = SafeBalance.addBigintBalance(currentBalance, stake + reward - txFee)
         operatorEVMAccount.account.balance = newBalance
         operatorEVMAccount.account.nonce = operatorEVMAccount.account.nonce + BigInt(1)
 
@@ -4099,7 +4099,7 @@ const shardusSetup = (): void => {
             stake,
             reward,
             penalty,
-            totalUnstakeAmount: stake + reward - penalty,
+            totalUnstakeAmount: stake + reward,
           }
         } else {
           stakeInfo = {


### PR DESCRIPTION
Fixes bug bounty https://linear.app/shm/issue/BLUE-228/[bug-bounty]-33813-double-slashing-of-validators