### PR TITLE
Add flag to disable smart contract endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6465,7 +6465,7 @@ const shardusSetup = (): void => {
           ShardeumFlags.StakingEnabled && numActiveNodes >= ShardeumFlags.minActiveNodesForStaking
 
         //Checks for golden ticket
-        if (appJoinData.adminCert?.goldenTicket === true && appJoinData.mustUseAdminCert === true) {
+        if (appJoinData.adminCert?.goldenTicket === true || appJoinData.mustUseAdminCert === true) {
           const adminCert: AdminCert = appJoinData.adminCert
           /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-mode', 'validateJoinRequest: Golden ticket is enabled, node about to enter processing check')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6465,7 +6465,7 @@ const shardusSetup = (): void => {
           ShardeumFlags.StakingEnabled && numActiveNodes >= ShardeumFlags.minActiveNodesForStaking
 
         //Checks for golden ticket
-        if (appJoinData.adminCert?.goldenTicket === true || appJoinData.mustUseAdminCert === true) {
+        if (appJoinData.adminCert?.goldenTicket === true) {
           const adminCert: AdminCert = appJoinData.adminCert
           /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-mode', 'validateJoinRequest: Golden ticket is enabled, node about to enter processing check')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1312,6 +1312,10 @@ const configShardusEndpoints = (): void => {
   }
 
   shardus.registerExternalPost('inject-with-warmup', externalApiMiddleware, async (req, res) => {
+    if (ShardeumFlags.disableSmartContractEndpoints) {
+      return res.json({ result: null, error: 'Smart contract endpoints are disabled' })
+    }
+    
     try {
       const id = shardus.getNodeId()
       const isInRotationBonds = shardus.isNodeInRotationBounds(id)
@@ -1666,6 +1670,10 @@ const configShardusEndpoints = (): void => {
   })
 
   shardus.registerExternalGet('eth_getCode', externalApiMiddleware, async (req, res) => {
+    if (ShardeumFlags.disableSmartContractEndpoints) {
+      return res.json({ contractCode: '0x' })
+    }
+
     if (trySpendServicePoints(ShardeumFlags.ServicePoints['eth_getCode'], req, 'account') === false) {
       return res.json({ error: 'node busy' })
     }
@@ -1737,6 +1745,9 @@ const configShardusEndpoints = (): void => {
     // if(isDebugMode()){
     //   return res.json(`endpoint not available`)
     // }
+    if (ShardeumFlags.disableSmartContractEndpoints) {
+      return res.json({ result: null, error: 'Smart contract endpoints are disabled' })
+    }
     if (
       trySpendServicePoints(ShardeumFlags.ServicePoints['contract/call'].endpoint, req, 'call-endpoint') ===
       false
@@ -1934,6 +1945,9 @@ const configShardusEndpoints = (): void => {
   })
 
   shardus.registerExternalPost('contract/accesslist', externalApiMiddleware, async (req, res) => {
+    if (ShardeumFlags.disableSmartContractEndpoints) {
+      return res.json({ result: null, error: 'Smart contract endpoints are disabled' })
+    }
     if (
       trySpendServicePoints(
         ShardeumFlags.ServicePoints['contract/accesslist'].endpoint,
@@ -1958,6 +1972,9 @@ const configShardusEndpoints = (): void => {
   })
 
   shardus.registerExternalPost('contract/accesslist-warmup', externalApiMiddleware, async (req, res) => {
+    if (ShardeumFlags.disableSmartContractEndpoints) {
+      return res.json({ result: null, error: 'Smart contract endpoints are disabled' })
+    }
     if (
       trySpendServicePoints(
         ShardeumFlags.ServicePoints['contract/accesslist'].endpoint,

--- a/src/setup/validateTxnFields.ts
+++ b/src/setup/validateTxnFields.ts
@@ -247,6 +247,18 @@ export const validateTxnFields =
           reason = ''
         }
 
+        // Chain ID validation
+        let chainId = BigInt(-1)
+        if (transaction && transaction.common.chainId) {
+          chainId = transaction.common.chainId()
+        }
+        if (chainId !== BigInt(ShardeumFlags.ChainID)) {
+          nestedCountersInstance.countEvent('shardeum', 'validate - invalid chain ID')
+          success = false
+          reason = `Transaction chain ID is invalid.`
+          /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log(`chain ID fail: chain ID: ${chainId}, Shardus Chain ID: ${ShardeumFlags.ChainID}`)
+        }
+
         if (ShardeumFlags.txBalancePreCheck && appData != null) {
           let minBalance: bigint // Calculate the minimun balance with the transaction value added in
           if (ShardeumFlags.chargeConstantTxFee) {

--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -121,6 +121,7 @@ interface ShardeumFlags {
   beta1_11_2: boolean
   failedStakeReceipt: boolean // For stake/unstake TXs that fail the checks in apply(), create an EVM receipt marked as failed
   debugDefaultBalance: string
+  disableSmartContractEndpoints: boolean
 }
 
 export const ShardeumFlags: ShardeumFlags = {
@@ -278,6 +279,7 @@ export const ShardeumFlags: ShardeumFlags = {
   unifiedAccountBalanceEnabled: true,
   failedStakeReceipt: true,
   debugDefaultBalance: '100', //In debug mode the default value is 100 SHM.  This is needed for certain load test operations
+  disableSmartContractEndpoints: true // Disable smart contract read endpoints by default
 }
 
 export function updateShardeumFlag(key: string, value: string | number | boolean): void {

--- a/src/vm_v7/runTx.ts
+++ b/src/vm_v7/runTx.ts
@@ -130,6 +130,19 @@ export async function runTx(this: VM, opts: RunTxOpts, evm: EthereumVirtualMachi
     }
   }
 
+  // chainId validation
+  const chainId = opts.tx.common.chainId()
+  if (BigInt(chainId) !== BigInt(ShardeumFlags.ChainID)) {
+    await evm.journal.revert()
+    const msg = _errorMsg(
+      `Invalid chainId: expected ${ShardeumFlags.ChainID}, got ${chainId}`,
+      this,
+      opts.block,
+      opts.tx
+    )
+    throw new Error(msg)
+  }
+
   try {
     const result = await _runTx.bind(this)(opts, evm, txid)
     await evm.journal.commit()


### PR DESCRIPTION
https://linear.app/shm/issue/GOLD-216

Generated description:

This pull request adds a new flag, `disableSmartContractEndpoints`, which allows the smart contract read endpoints to be disabled. This flag is set to `true` by default. The changes include modifications to the handler functions to check the flag before processing requests to the smart contract endpoints. Additionally, the `ShardeumFlags` interface and its default values have been updated to include the new flag. This enhancement provides more control over the availability of smart contract endpoints.