### PR TITLE
Fix:  ChainId validation to prevent cross chain replay attacks

### DIFF
--- a/src/setup/validateTxnFields.ts
+++ b/src/setup/validateTxnFields.ts
@@ -247,6 +247,18 @@ export const validateTxnFields =
           reason = ''
         }
 
+        // Chain ID validation
+        let chainId = BigInt(-1)
+        if (transaction && transaction.common.chainId) {
+          chainId = transaction.common.chainId()
+        }
+        if (chainId !== BigInt(ShardeumFlags.ChainID)) {
+          nestedCountersInstance.countEvent('shardeum', 'validate - invalid chain ID')
+          success = false
+          reason = `Transaction chain ID is invalid.`
+          /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log(`chain ID fail: chain ID: ${chainId}, Shardus Chain ID: ${ShardeumFlags.ChainID}`)
+        }
+
         if (ShardeumFlags.txBalancePreCheck && appData != null) {
           let minBalance: bigint // Calculate the minimun balance with the transaction value added in
           if (ShardeumFlags.chargeConstantTxFee) {

--- a/src/vm_v7/runTx.ts
+++ b/src/vm_v7/runTx.ts
@@ -130,6 +130,19 @@ export async function runTx(this: VM, opts: RunTxOpts, evm: EthereumVirtualMachi
     }
   }
 
+  // chainId validation
+  const chainId = opts.tx.common.chainId()
+  if (BigInt(chainId) !== BigInt(ShardeumFlags.ChainID)) {
+    await evm.journal.revert()
+    const msg = _errorMsg(
+      `Invalid chainId: expected ${ShardeumFlags.ChainID}, got ${chainId}`,
+      this,
+      opts.block,
+      opts.tx
+    )
+    throw new Error(msg)
+  }
+
   try {
     const result = await _runTx.bind(this)(opts, evm, txid)
     await evm.journal.commit()


### PR DESCRIPTION
The code changes add chainId validation to the runTx function in the `runTx.ts` file. This ensures that the chainId provided in the transaction matches the expected chainId. If the chainId is invalid, an error is thrown.