### PR TITLE
SYS-487 Default Balance  fix and patch

### DIFF
--- a/debug-0-starting-balance.patch
+++ b/debug-0-starting-balance.patch
@@ -1,0 +1,7 @@
+diff --git a/src/shardeum/shardeumFlags.ts b/src/shardeum/shardeumFlags.ts
+index c126e73f..45c47378 100644
+--- a/src/shardeum/shardeumFlags.ts
++++ b/src/shardeum/shardeumFlags.ts
+@@ -280 +280 @@ export const ShardeumFlags: ShardeumFlags = {
+-  debugDefaultBalance: '100', //In debug mode the default value is 100 SHM.  This is needed for certain load test operations
++  debugDefaultBalance: '0', //In debug mode the default value is 100 SHM.  This is needed for certain load test operations

--- a/debug-0-starting-balance.patch
+++ b/debug-0-starting-balance.patch
@@ -2,6 +2,8 @@ diff --git a/src/shardeum/shardeumFlags.ts b/src/shardeum/shardeumFlags.ts
 index c126e73f..45c47378 100644
 --- a/src/shardeum/shardeumFlags.ts
 +++ b/src/shardeum/shardeumFlags.ts
-@@ -280 +280 @@ export const ShardeumFlags: ShardeumFlags = {
+@@ -279,3 +279,3 @@ export const ShardeumFlags: ShardeumFlags = {
+   failedStakeReceipt: true,
 -  debugDefaultBalance: '100', //In debug mode the default value is 100 SHM.  This is needed for certain load test operations
 +  debugDefaultBalance: '0', //In debug mode the default value is 100 SHM.  This is needed for certain load test operations
+ }

--- a/debug-0-starting-balance.patch
+++ b/debug-0-starting-balance.patch
@@ -1,5 +1,5 @@
 diff --git a/src/shardeum/shardeumFlags.ts b/src/shardeum/shardeumFlags.ts
-index 5b212250..b61484e8 100644
+index db96cf07..ea6d50f9 100644
 --- a/src/shardeum/shardeumFlags.ts
 +++ b/src/shardeum/shardeumFlags.ts
 @@ -278,7 +278,7 @@ export const ShardeumFlags: ShardeumFlags = {
@@ -7,7 +7,7 @@ index 5b212250..b61484e8 100644
    unifiedAccountBalanceEnabled: true,
    failedStakeReceipt: true,
 -  debugDefaultBalance: '100', //In debug mode the default value is 100 SHM.  This is needed for certain load test operations
-+  debugDefaultBalance: '0', //In debug mode the default value is 100 SHM.  This is needed for certain load test operations
++  debugDefaultBalance: '0', // setting default balance to 0 while in debug mode
    disableSmartContractEndpoints: true // Disable smart contract read endpoints by default
  }
  

--- a/debug-0-starting-balance.patch
+++ b/debug-0-starting-balance.patch
@@ -1,9 +1,13 @@
 diff --git a/src/shardeum/shardeumFlags.ts b/src/shardeum/shardeumFlags.ts
-index c126e73f..45c47378 100644
+index 5b212250..b61484e8 100644
 --- a/src/shardeum/shardeumFlags.ts
 +++ b/src/shardeum/shardeumFlags.ts
-@@ -279,3 +279,3 @@ export const ShardeumFlags: ShardeumFlags = {
+@@ -278,7 +278,7 @@ export const ShardeumFlags: ShardeumFlags = {
+ 
+   unifiedAccountBalanceEnabled: true,
    failedStakeReceipt: true,
 -  debugDefaultBalance: '100', //In debug mode the default value is 100 SHM.  This is needed for certain load test operations
 +  debugDefaultBalance: '0', //In debug mode the default value is 100 SHM.  This is needed for certain load test operations
+   disableSmartContractEndpoints: true // Disable smart contract read endpoints by default
  }
+ 

--- a/src/index.ts
+++ b/src/index.ts
@@ -468,7 +468,7 @@ const appliedTxs = {} //this appears to be unused. will it still be unused if we
 const shardusTxIdToEthTxId = {} //this appears to only support appliedTxs
 
 //In debug mode the default value is 100 SHM.  This is needed for certain load test operations
-const defaultBalance = isDebugMode() ? oneSHM * BigInt(100) : BigInt(0)
+const defaultBalance = isDebugMode() ? oneSHM * BigInt(ShardeumFlags.debugDefaultBalance) : BigInt(0)
 
 // TODO move this to a db table
 // const transactionFailHashMap: any = {}


### PR DESCRIPTION
- adds a fix to evm init so that the default balance is correctly pulled from the config
- adds a patch file which sets the default balance to 0 so we can run debug tests with 0 balance accounts.