### PR TITLE
GOLD-217: remove binary internal endpoint flags

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -199,7 +199,6 @@ config = merge(config, {
 
       forcedMode: '', //change to 'safety` to force network into safety mode (other modes not implemented and will not force network mode)
       // 1.10.x ? dev test   needs migration to release
-      // useBinarySerializedEndpoints: true,
       // 1.10 x ? dev test   needs migration to release
       removeLostSyncingNodeFromList: true,
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -199,7 +199,7 @@ config = merge(config, {
 
       forcedMode: '', //change to 'safety` to force network into safety mode (other modes not implemented and will not force network mode)
       // 1.10.x ? dev test   needs migration to release
-      useBinarySerializedEndpoints: true,
+      // useBinarySerializedEndpoints: true,
       // 1.10 x ? dev test   needs migration to release
       removeLostSyncingNodeFromList: true,
 

--- a/test/multiSig.test.ts
+++ b/test/multiSig.test.ts
@@ -14,7 +14,7 @@ const changeConfigTx: any = {
   internalTXType: 3,
   timestamp: Date.now(),
   from: wallet.publicKey,
-  config: '{"p2p":{"useBinarySerializedEndpoints":true}}',
+  config: '{"p2p":{"cycleDuration":60}}',
   cycle: -1,
 }
 


### PR DESCRIPTION
Linear: https://linear.app/shm/issue/GOLD-217

Summary: Cleanup internal endpoint flags added during binary migration