### PR TITLE
PM-151 Fixes for ITN3 RC1

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -278,10 +278,15 @@ config = merge(config, {
 
       forwardToLuckyNodes: false, // 1.11.0 we seem to have more issues with this on.  can turn off for local testing
 
-      removeStuckTxsFromQueue: false,
+      removeStuckTxsFromQueue: true,
+      removeStuckTxsFromQueue3: true,
+
       removeStuckChallengedTXs: false,
 
       stuckTxMoveTime: 3600000,
+
+      stuckTxRemoveTime: 600000, // 10 min
+      stuckTxRemoveTime3: 300000, // 5 min
 
       awaitingDataCanBailOnReceipt: true,
     },

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -371,6 +371,7 @@ config = merge(
           '0x0a0844DA5e01E391d12999ca859Da8a897D5979A': DevSecurityLevel.High, // test key
           '0x390878B18DeBe2A9f0d5c0252a109c84243D3beb': DevSecurityLevel.High, // test key
           '0x32B6f2C027D4c9D99Ca07d047D17987390a5EB39': DevSecurityLevel.High, // test key
+          '0x80aF8E195B56aCC3b4ec8e2C99EC38957258635a': DevSecurityLevel.High, // Atharva
         },
         checkAddressFormat: true, //enabled for 1.10.0
         enableCycleRecordDebugTool: false, // only enable if you want to debug variant cycle records

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -374,6 +374,8 @@ config = merge(
         checkAddressFormat: true, //enabled for 1.10.0
         enableCycleRecordDebugTool: false, // only enable if you want to debug variant cycle records
         enableScopedProfiling: false,
+        minMultiSigRequiredForEndpoints: 1,
+        minMultiSigRequiredForGlobalTxs: 1,
       },
     },
   },

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -372,6 +372,7 @@ config = merge(
           '0x390878B18DeBe2A9f0d5c0252a109c84243D3beb': DevSecurityLevel.High, // test key
           '0x32B6f2C027D4c9D99Ca07d047D17987390a5EB39': DevSecurityLevel.High, // test key
           '0x80aF8E195B56aCC3b4ec8e2C99EC38957258635a': DevSecurityLevel.High, // Atharva
+          '0x3d3E0A9DdCC3348Fc81daDED2e72eC0CaC870ABD': DevSecurityLevel.High, // test key ( Jai )
         },
         checkAddressFormat: true, //enabled for 1.10.0
         enableCycleRecordDebugTool: false, // only enable if you want to debug variant cycle records

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -370,6 +370,7 @@ config = merge(
           '0x002D3a2BfE09E3E29b6d38d58CaaD16EEe4C9BC5': DevSecurityLevel.High, // test key
           '0x0a0844DA5e01E391d12999ca859Da8a897D5979A': DevSecurityLevel.High, // test key
           '0x390878B18DeBe2A9f0d5c0252a109c84243D3beb': DevSecurityLevel.High, // test key
+          '0x32B6f2C027D4c9D99Ca07d047D17987390a5EB39': DevSecurityLevel.High, // test key
         },
         checkAddressFormat: true, //enabled for 1.10.0
         enableCycleRecordDebugTool: false, // only enable if you want to debug variant cycle records

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -367,12 +367,19 @@ config = merge(
           // always prefix with prettier ignore
         },
         multisigKeys: {
-          '0x002D3a2BfE09E3E29b6d38d58CaaD16EEe4C9BC5': DevSecurityLevel.High, // test key
-          '0x0a0844DA5e01E391d12999ca859Da8a897D5979A': DevSecurityLevel.High, // test key
-          '0x390878B18DeBe2A9f0d5c0252a109c84243D3beb': DevSecurityLevel.High, // test key
-          '0x32B6f2C027D4c9D99Ca07d047D17987390a5EB39': DevSecurityLevel.High, // test key
-          '0x80aF8E195B56aCC3b4ec8e2C99EC38957258635a': DevSecurityLevel.High, // Atharva
-          '0x3d3E0A9DdCC3348Fc81daDED2e72eC0CaC870ABD': DevSecurityLevel.High, // test key ( Jai )
+          // always prefix with prettier ignore
+          /* prettier-ignore */ '0x002D3a2BfE09E3E29b6d38d58CaaD16EEe4C9BC5': DevSecurityLevel.High, // test key
+          /* prettier-ignore */ '0x0a0844DA5e01E391d12999ca859Da8a897D5979A': DevSecurityLevel.High, // test key
+          /* prettier-ignore */ '0x390878B18DeBe2A9f0d5c0252a109c84243D3beb': DevSecurityLevel.High, // test key
+          /* prettier-ignore */ '0x32B6f2C027D4c9D99Ca07d047D17987390a5EB39': DevSecurityLevel.High, // test key
+          /* prettier-ignore */ '0x80aF8E195B56aCC3b4ec8e2C99EC38957258635a': DevSecurityLevel.High, // Atharva
+          /* prettier-ignore */ '0x3d3E0A9DdCC3348Fc81daDED2e72eC0CaC870ABD': DevSecurityLevel.High, // test key ( Jai )
+          /* prettier-ignore */ '0x7Efbb31431ac7C405E8eEba99531fF1254fCA3B6': DevSecurityLevel.High, // test key ( M1 )
+          /* prettier-ignore */ '0xCc74bf387F6C102b5a7F828796C57A6D2D19Cb00': DevSecurityLevel.High, // test key ( M2 )
+          /* prettier-ignore */ '0x4ed5C053BF2dA5F694b322EA93dce949F3276B85': DevSecurityLevel.High, // test key ( M3 )
+          /* prettier-ignore */ '0xd31aBC7497aD8bC9fe8555C9eDe45DFd7FB3Bf6F': DevSecurityLevel.High, // test key ( M4 )
+          /* prettier-ignore */ '0xe7e4cc292b424C6D50d16F1Bb5BAB2032c486980': DevSecurityLevel.High, // test key ( M5 )
+          // always prefix with prettier ignore
         },
         checkAddressFormat: true, //enabled for 1.10.0
         enableCycleRecordDebugTool: false, // only enable if you want to debug variant cycle records

--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -257,7 +257,7 @@ export const ShardeumFlags: ShardeumFlags = {
   ],
   controlledRPCEndpoints: ['contract/estimateGas'],
   numberOfNodesToInjectPenaltyTx: 5,
-  loadGenesisNodeNetworkConfigToNetworkAccount: false,
+  loadGenesisNodeNetworkConfigToNetworkAccount: true,
   networkAccountCacheDuration: 3600, // 60 minutes
   enableClaimRewardAdminCert: true,
   debugLocalAALG: false,


### PR DESCRIPTION
1.) Turn on loadGenesisNodeNetworkConfigToNetworkAccount true by default.

2.) Turn on 2 removeStuckTxs from queue configs by default.

3.) Set # multi-sig signatures to 1 (temporarily) until we have had the walk-thru and instructional meeting on using the app.

4.) Add a number of multi-sig signer keys.

BONUS:  A removal of extra unneeded .patch failes (was already in pre-dev.)