### PR TITLE
GOLD-277 : update nodesPerConsensusGroup to be a static value

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -265,9 +265,7 @@ config = merge(config, {
 config = merge(config, {
   server: {
     sharding: {
-      nodesPerConsensusGroup: process.env.nodesPerConsensusGroup
-        ? parseInt(process.env.nodesPerConsensusGroup)
-        : 32, //128 is the final goal
+      nodesPerConsensusGroup: 32, //128 is the final goal
       nodesPerEdge: process.env.nodesPerEdge ? parseInt(process.env.nodesPerEdge) : 5,
       executeInOneShard: true,
     },


### PR DESCRIPTION
linear: https://linear.app/shm/issue/GOLD-277/required-minimum-for-consensus-should-be-static-not-dynamic-number