### PR TITLE
SHARD-254: remove string matching check to avoid string case errors

### DIFF
--- a/src/setup/helpers.ts
+++ b/src/setup/helpers.ts
@@ -131,6 +131,7 @@ export function verifyMultiSigs(
   const seen = new Set()
 
   for (let i = 0; i < sigs.length; i++) {
+    /* eslint-disable security/detect-object-injection */
     // The sig owner has not been seen before
     // The sig owner is listed on the server
     // The sig owner has enough security clearance
@@ -139,11 +140,12 @@ export function verifyMultiSigs(
       !seen.has(sigs[i].owner) &&
       allowedPubkeys[sigs[i].owner] &&
       allowedPubkeys[sigs[i].owner] >= requiredSecurityLevel &&
-      ethers.verifyMessage(payload_hash, sigs[i].sig) === sigs[i].owner
+      ethers.verifyMessage(payload_hash, sigs[i].sig).toLowerCase() === sigs[i].owner.toLowerCase()
     ) {
       validSigs++
       seen.add(sigs[i].owner)
     }
+    /* eslint-enable security/detect-object-injection */
 
     if (validSigs >= minSigRequired) break
   }

--- a/src/setup/helpers.ts
+++ b/src/setup/helpers.ts
@@ -120,6 +120,9 @@ export function verifyMultiSigs(
   minSigRequired: number,
   requiredSecurityLevel: DevSecurityLevel
 ): boolean {
+  if (!rawPayload || !sigs || !allowedPubkeys || !Array.isArray(sigs)) {
+    return false
+  }
   if (sigs.length < minSigRequired) return false
 
   // no reason to allow more signatures than allowedPubkeys exist


### PR DESCRIPTION
https://linear.app/shm/issue/GOLD-280/

If not fixed, the side effect is that keys are case-sensitive.