### PR TITLE
SHARD-1061: Moved call to isDebugTx to after isInternalTxn in function validateTxnFields

### DIFF
--- a/src/setup/validateTxnFields.ts
+++ b/src/setup/validateTxnFields.ts
@@ -74,14 +74,6 @@ export const validateTxnFields =
       }
       const txId = generateTxId(tx)
 
-      if (isDebugTx(tx)) {
-        return {
-          success: true,
-          reason: 'always valid',
-          txnTimestamp,
-        }
-      }
-
       if (isSetCertTimeTx(tx)) {
         const setCertTimeTx = tx as SetCertTime
         const result = validateSetCertTimeTx(setCertTimeTx)
@@ -195,6 +187,14 @@ export const validateTxnFields =
           success,
           reason,
           txnTimestamp: txnTimestamp,
+        }
+      }
+
+      if (isDebugTx(tx)) {
+        return {
+          success: true,
+          reason: 'always valid',
+          txnTimestamp,
         }
       }
 


### PR DESCRIPTION
Fix for Bug Bounty ticket that pointed out that a transaction that passes the iDebugTx property as true can bypass all other checks. This was inconsistent with other implementations that use both isDebugTx and isInternalTx checks.