### PR TITLE
SHARD-999 npm migration 

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@ethereumjs/util": "^9.0.0",
     "@ethereumjs/vm": "7.0.0",
     "@mapbox/node-pre-gyp": "1.0.10",
-    "@shardus/archiver-discovery": "1.1.0",
+    "@shardus/archiver-discovery": "git+https://github.com/shardeum/archive-server/#v1.1.0",
     "@shardus/core": "git+https://github.com/shardeum/shardus-core#dev",
     "@shardus/crypto-utils": "git+https://github.com/shardeum/lib-crypto-utils#v4.1.5",
     "@shardus/net": "git+https://github.com/shardeum/lib-net#v1.4.0",


### PR DESCRIPTION
- migrating missed repo

:warning: might be an issue here. Shardeum server build fails after I switch that @shardus/archiver-discovery to point at github

package lock file needs to be updated