### PR TITLE
fix: add checkpointing / automicity to secure account updates

### DIFF
--- a/test/unit/src/shardeum/secureAccounts.test.ts
+++ b/test/unit/src/shardeum/secureAccounts.test.ts
@@ -31,13 +31,17 @@ jest.mock('@shardus/core', () => {
         '0x123': 2
       }),
       applyResponseAddChangedAccount: jest.fn(),
-      applyResponseAddReceiptData: jest.fn()
+      applyResponseAddReceiptData: jest.fn(),
+      setDebugSetLastAppAwait: jest.fn()
     })),
     VectorBufferStream: actual.VectorBufferStream,
     DevSecurityLevel: {
       High: 2,
       Medium: 1,
       Low: 0
+    },
+    DebugComplete: {
+      Completed: 'Completed'
     }
   }
 })
@@ -62,7 +66,13 @@ jest.mock('../../../../src', () => ({
       minMultisigRequiredForGlobalTxs: 1
     }
   },
-  createInternalTxReceipt: jest.fn()
+  createInternalTxReceipt: jest.fn(),
+  getApplyTXState: jest.fn().mockReturnValue({
+    checkpoint: jest.fn().mockResolvedValue(undefined),
+    commit: jest.fn().mockResolvedValue(undefined),
+    revert: jest.fn().mockResolvedValue(undefined),
+    putAccount: jest.fn().mockResolvedValue(undefined)
+  })
 }))
 
 describe('secureAccounts', () => {


### PR DESCRIPTION
# Add Transaction Atomicity to Secure Accounts

## Changes Overview
This PR enhances the secure accounts transaction handling by implementing atomic transactions in the `apply` function within `secureAccounts.ts`. 

### Key Changes:
1. **Added Transaction Atomicity**
   - Implemented checkpoint-commit-revert pattern using `shardeumState`
   - All account updates are now wrapped in a try-catch block
   - Changes are only committed if all operations succeed
   - On failure, all changes are reverted

2. **Code Organization**
   - Added new imports from `@ethereumjs/util` and `@shardus/core`
   - Restructured account updates to be within the atomic transaction block
   - Added debug tracking for transaction checkpoints

3. **State Management**
   - Now using `shardeumState.putAccount` for explicit account state updates
   - Added proper error handling with transaction rollback
   - Improved account state consistency guarantees

## Purpose
This change ensures that secure account transactions are atomic - they either complete fully or not at all. This prevents partial updates that could leave the system in an inconsistent state if an error occurs during the transaction process.

## Technical Details
- Uses `checkpoint()` to mark the start of the transaction
- All account modifications are wrapped in a try-catch block
- On success: calls `commit()` to persist changes
- On failure: calls `revert()` to roll back all changes
- Added debug tracking using `setDebugSetLastAppAwait`

