### PR TITLE
SHARD-1167 - feat(violations): Add violation tracking for license points system

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,7 @@ export let genesisAccounts: string[] = []
 // Two global variables: at the top of utils/versions.ts
 // Where to call this function: After shradus factory line 146 console.logs ke pehle
 // Add a console log to log out to fetched versions
-// “getNodeInfoAppData()”
+// "getNodeInfoAppData()"
 
 const ERC20_BALANCEOF_CODE = '0x70a08231'
 
@@ -3129,6 +3129,14 @@ const createNodeAccount2 = (accountId: string): NodeAccount2 => {
       penaltyHistory: [],
       lastPenaltyTime: 0,
       isShardeumRun: false,
+      // Initialize violation counts
+      violationCounts: {
+        [ViolationType.LeftNetworkEarly]: 0,
+        [ViolationType.SyncingTooLong]: 0,
+        [ViolationType.NodeRefuted]: 0,
+        [ViolationType.DoubleVote]: 0
+      },
+      lastViolationTime: 0
     },
     rewarded: false,
     rewardRate: BigInt(0),

--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -1,4 +1,4 @@
-import { DecimalString } from './shardeumTypes'
+import { DecimalString, ViolationType } from './shardeumTypes'
 
 interface ShardeumFlags {
   contractStorageKeySilo: boolean
@@ -123,6 +123,9 @@ interface ShardeumFlags {
   failedStakeReceipt: boolean // For stake/unstake TXs that fail the checks in apply(), create an EVM receipt marked as failed
   debugDefaultBalance: string
   disableSmartContractEndpoints: boolean
+  violationWeights: {
+    [key in ViolationType]: number;
+  }
 }
 
 export const ShardeumFlags: ShardeumFlags = {
@@ -283,6 +286,14 @@ export const ShardeumFlags: ShardeumFlags = {
   failedStakeReceipt: true,
   debugDefaultBalance: '100', //In debug mode the default value is 100 SHM.  This is needed for certain load test operations
   disableSmartContractEndpoints: true, // Disable smart contract read endpoints by default
+
+  // Default violation weights in minutes
+  violationWeights: {
+    [ViolationType.LeftNetworkEarly]: 180,  // 3 hours
+    [ViolationType.SyncingTooLong]: 30,     // 30 minutes
+    [ViolationType.NodeRefuted]: 30,        // 30 minutes
+    [ViolationType.DoubleVote]: 360         // 6 hours
+  }
 }
 
 export function updateShardeumFlag(key: string, value: string | number | boolean): void {

--- a/src/shardeum/shardeumTypes.ts
+++ b/src/shardeum/shardeumTypes.ts
@@ -429,6 +429,11 @@ export interface NodeAccountStats {
   penaltyHistory: { type: ViolationType; amount: bigint; timestamp: number }[]
   //set when first staked
   isShardeumRun: boolean
+  // Track violation counts for license points system
+  violationCounts: {
+    [key in ViolationType]: number;
+  }
+  lastViolationTime: number
 }
 
 export interface DevAccount extends BaseAccount {

--- a/src/tx/penalty/transaction.ts
+++ b/src/tx/penalty/transaction.ts
@@ -259,6 +259,11 @@ export async function applyPenaltyTX(
   //TODO should we check if it was already penalized?
   const penaltyAmount = getPenaltyForViolation(tx, nodeAccount.stakeLock)
   applyPenalty(nodeAccount, operatorAccount, penaltyAmount)
+  
+  // Update violation counts
+  nodeAccount.nodeAccountStats.violationCounts[tx.violationType]++
+  nodeAccount.nodeAccountStats.lastViolationTime = eventTime
+  
   nodeAccount.nodeAccountStats.penaltyHistory.push({
     type: tx.violationType,
     amount: penaltyAmount,


### PR DESCRIPTION
This commit adds infrastructure to track node violations over time, replacing the slashing mechanism with a license points system. Changes include: Add violationCounts and lastViolationTime to NodeAccountStats, add configurable violation weights in ShardeumFlags, initialize violation tracking in node account creation, and update violation counts when applying penalties. The actual node rotation logic will be implemented in the core library.