### PR TITLE
SHARD-1248 : Add Operations SecureAccount with 5 million SHM

### DIFF
--- a/src/config/genesis-secure-accounts.json
+++ b/src/config/genesis-secure-accounts.json
@@ -33,5 +33,12 @@
     "RecipientFundsAddress": "0x1be3e07e7c4c2e568c590f71234e0c03f2348734",
     "SecureAccountAddress": "5916018611b4958ab9dc963df642d0b6bcff15a9000000000000000000000000",
     "SourceFundsBalance": "5080000000000000000000000"
+  },
+  {
+    "Name": "Operations",
+    "SourceFundsAddress": "0xffffffffffffffffffffffffffffffffffffffff",
+    "RecipientFundsAddress": "0x633D35F7Fb28d6C6CDa3108253D2d5C799b58c54",
+    "SecureAccountAddress": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    "SourceFundsBalance": "5000000000000000000000000"
   }
 ]


### PR DESCRIPTION
Add a new SecureAccount named 'Operations' with a starting balance of 5 million SHM.

* Modify `src/config/genesis-secure-accounts.json` to include the 'Operations' SecureAccount with the following details:
  - Name: "Operations"
  - SourceFundsAddress: "0xffffffffffffffffffffffffffffffffffffffff"
  - RecipientFundsAddress: "0x633D35F7Fb28d6C6CDa3108253D2d5C799b58c54"
  - SecureAccountAddress: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
  - SourceFundsBalance: "5000000000000000000000000"

https://linear.app/shm/issue/SHARD-1248/add-a-6th-secure-account-for-ops

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shardeum/shardeum/pull/293?shareId=0bb8fd80-eb9b-4741-8185-4143165fa9dc).

Goes with https://github.com/shardeum/tools-lt2/pull/122