### PR TITLE
Put basic network account verifications received from archiver behind a flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8049,7 +8049,7 @@ async function fetchNetworkAccountFromArchiver(): Promise<WrappedAccount> {
       )
     }
 
-    if (!ShardeumFlags.disableArchiverNetworkAccountValidation) {
+    if (ShardeumFlags.enableArchiverNetworkAccountValidation) {
       // basic validation of the data to make sure we wont get unexpected errors
       if (!res.data.networkAccount || !res.data.networkAccount.data || !res.data.networkAccount.data.hash) {
         throw new Error(`get-network-account from archiver pk:${majorityValue.archiver.publicKey} returned malformed data: ${safeStringify(res.data)}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8049,25 +8049,27 @@ async function fetchNetworkAccountFromArchiver(): Promise<WrappedAccount> {
       )
     }
 
-    // basic validation of the data to make sure we wont get unexpected errors
-    if (!res.data.networkAccount || !res.data.networkAccount.data || !res.data.networkAccount.data.hash) {
-      throw new Error(`get-network-account from archiver pk:${majorityValue.archiver.publicKey} returned malformed data: ${safeStringify(res.data)}`)
-    }
+    if (!ShardeumFlags.disableArchiverNetworkAccountValidation) {
+      // basic validation of the data to make sure we wont get unexpected errors
+      if (!res.data.networkAccount || !res.data.networkAccount.data || !res.data.networkAccount.data.hash) {
+        throw new Error(`get-network-account from archiver pk:${majorityValue.archiver.publicKey} returned malformed data: ${safeStringify(res.data)}`)
+      }
 
-    nestedCountersInstance.countEvent('network-config-operation', 'success: got network account from winning archiver')
+      nestedCountersInstance.countEvent('network-config-operation', 'success: got network account from winning archiver')
 
-    // verify the 'winning' archiver's signature of the network account matches that of the response body signature
-    const isResponseVerified = verify(res.data, majorityValue.archiver.publicKey)
-    if (!isResponseVerified) {
-      nestedCountersInstance.countEvent('network-config-operation', 'failure: The response signature is not the same from archiver pk:${majorityValue.archiver.publicKey}')
-      throw new Error(`The response signature is not the same from archiver pk:${majorityValue.archiver.publicKey}`)
-    }
+      // verify the 'winning' archiver's signature of the network account matches that of the response body signature
+      const isResponseVerified = verify(res.data, majorityValue.archiver.publicKey)
+      if (!isResponseVerified) {
+        nestedCountersInstance.countEvent('network-config-operation', 'failure: The response signature is not the same from archiver pk:${majorityValue.archiver.publicKey}')
+        throw new Error(`The response signature is not the same from archiver pk:${majorityValue.archiver.publicKey}`)
+      }
 
-    // verify that the hash was not spoofed by the archiver, rehash the network account and compare
-    const rehashedNetworkAccount = WrappedEVMAccountFunctions.accountSpecificHash(res.data.networkAccount.data)
-    if (rehashedNetworkAccount !== majorityValue.hash) {
-      nestedCountersInstance.countEvent('network-config-operation', 'failure: The rehashed network account is not the same as the majority hash')
-      throw new Error(`The rehashed network account is not the same as the majority hash. rehashed: ${rehashedNetworkAccount}, majority: ${majorityValue.hash}`)
+      // verify that the hash was not spoofed by the archiver, rehash the network account and compare
+      const rehashedNetworkAccount = WrappedEVMAccountFunctions.accountSpecificHash(res.data.networkAccount.data)
+      if (rehashedNetworkAccount !== majorityValue.hash) {
+        nestedCountersInstance.countEvent('network-config-operation', 'failure: The rehashed network account is not the same as the majority hash')
+        throw new Error(`The rehashed network account is not the same as the majority hash. rehashed: ${rehashedNetworkAccount}, majority: ${majorityValue.hash}`)
+      }
     }
 
     return res.data.networkAccount as WrappedAccount

--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -126,6 +126,7 @@ interface ShardeumFlags {
   debugGlobalAccountUpdateFail: boolean
   ticketTypesEnabled: boolean
   debugTxEnabled: boolean
+  disableArchiverNetworkAccountValidation: boolean
 }
 
 export const ShardeumFlags: ShardeumFlags = {
@@ -288,7 +289,8 @@ export const ShardeumFlags: ShardeumFlags = {
   disableSmartContractEndpoints: true, // Disable smart contract read endpoints by default
   debugGlobalAccountUpdateFail: false,
   ticketTypesEnabled: false,
-  debugTxEnabled: false
+  debugTxEnabled: false,
+  disableArchiverNetworkAccountValidation: true, //  Enable/disable network account basic validations from archiver
 }
 
 export function updateShardeumFlag(key: string, value: string | number | boolean): void {

--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -126,7 +126,7 @@ interface ShardeumFlags {
   debugGlobalAccountUpdateFail: boolean
   ticketTypesEnabled: boolean
   debugTxEnabled: boolean
-  disableArchiverNetworkAccountValidation: boolean
+  enableArchiverNetworkAccountValidation: boolean
 }
 
 export const ShardeumFlags: ShardeumFlags = {
@@ -290,7 +290,7 @@ export const ShardeumFlags: ShardeumFlags = {
   debugGlobalAccountUpdateFail: false,
   ticketTypesEnabled: false,
   debugTxEnabled: false,
-  disableArchiverNetworkAccountValidation: true, //  Enable/disable network account basic validations from archiver
+  enableArchiverNetworkAccountValidation: false, //  Enable/disable network account basic validations from archiver
 }
 
 export function updateShardeumFlag(key: string, value: string | number | boolean): void {


### PR DESCRIPTION
The basic validation of the network account retrieved from the archiver is now conditional on the value of the `disableArchiverNetworkAccountValidation` flag