### PR TITLE
Update accountsSyncCheck.ts

### DIFF
--- a/scripts/accountsSyncCheck.ts
+++ b/scripts/accountsSyncCheck.ts
@@ -144,7 +144,7 @@ export async function queryAccountsFromArchiver(skip = 0, limit = 10000): Promis
   try {
     const sql = `SELECT * FROM accounts ORDER BY cycleNumber ASC, timestamp ASC LIMIT ${limit} OFFSET ${skip}`
     accounts = await all(sql)
-    if (accounts.lenth > 0) {
+    if (accounts.length > 0) {
       accounts.map((account) => {
         if (account && account.data) account.data = Utils.safeJsonParse(account.data)
       })


### PR DESCRIPTION
    if (accounts.lenth > 0) { // Old code with typo
    if (accounts.length > 0) { // Corrected code
    
    Reason for Change: The original word "lenth" is a typographical error. The correct term is "length," which is a property used to determine the number of elements in an array. This change ensures that the code functions correctly by accurately checking if the accounts array contains any element