### PR TITLE
SHARD-1886: Implement whitehat suggested changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ import { Block } from '@ethereumjs/block'
 import { ShardeumBlock } from './block/blockchain'
 import * as AccountsStorage from './storage/accountStorage'
 import { sync, validateTransaction, validateTxnFields } from './setup'
-import { applySetCertTimeTx, injectSetCertTimeTx, getCertCycleDuration } from './tx/setCertTime'
+import { applySetCertTimeTx, injectSetCertTimeTx, getCertCycleDuration, isSetCertTimeTx } from './tx/setCertTime'
 import { applyClaimRewardTx, injectClaimRewardTx } from './tx/claimReward'
 import { Request, Response } from 'express'
 import {
@@ -3004,7 +3004,7 @@ async function applyInternalTx(
     /* prettier-ignore */ if (logFlags.important_as_error) console.log(`Applied CHANGE_NETWORK_PARAM GLOBAL transaction: ${Utils.safeStringify(network)}`)
     /* prettier-ignore */ if (logFlags.important_as_error) shardus.log('Applied CHANGE_NETWORK_PARAM GLOBAL transaction', Utils.safeStringify(network))
   }
-  if (internalTx.internalTXType === InternalTXType.SetCertTime) {
+  if (isSetCertTimeTx(internalTx)) {
     const setCertTimeTx = internalTx as SetCertTime
     applySetCertTimeTx(shardus, setCertTimeTx, wrappedStates, txId, txTimestamp, applyResponse)
   }
@@ -5543,7 +5543,7 @@ const shardusSetup = (): void => {
           keys.targetKeys = [networkAccount]
         } else if (internalTx.internalTXType === InternalTXType.ApplyNetworkParam) {
           keys.targetKeys = [networkAccount]
-        } else if (internalTx.internalTXType === InternalTXType.SetCertTime) {
+        } else if (isSetCertTimeTx(internalTx)) {
           keys.sourceKeys = [tx.nominee]
           keys.targetKeys = [toShardusAddress(tx.nominator, AccountType.Account), networkAccount]
         } else if (internalTx.internalTXType === InternalTXType.InitRewardTimes) {
@@ -5989,7 +5989,7 @@ const shardusSetup = (): void => {
             }
           }
         }
-        if (internalTx.internalTXType === InternalTXType.SetCertTime) {
+        if (isSetCertTimeTx(internalTx)) {
           if (!wrappedEVMAccount) {
             // Node Account or EVM Account(Nominator) has to be already created at this point.
             if (accountId === internalTx.nominee) {
@@ -7966,7 +7966,7 @@ const shardusSetup = (): void => {
           return internalTx.from
         } else if (internalTx.internalTXType === InternalTXType.ApplyNetworkParam) {
           return internalTx.network
-        } else if (internalTx.internalTXType === InternalTXType.SetCertTime) {
+        } else if (isSetCertTimeTx(internalTx)) {
           return internalTx.nominee
         } else if (internalTx.internalTXType === InternalTXType.InitRewardTimes) {
           return internalTx.nominee

--- a/src/setup/helpers.ts
+++ b/src/setup/helpers.ts
@@ -32,7 +32,6 @@ export function isInternalTXGlobal(internalTx: InternalTx): boolean {
 export function isInternalTx(timestampedTx: any): boolean {
   if (timestampedTx && timestampedTx.raw) return false
   if (timestampedTx && timestampedTx.isInternalTx) return true
-  if (timestampedTx && timestampedTx.tx && timestampedTx.tx.isInternalTx) return true
   return false
 }
 

--- a/src/setup/validateTransaction.ts
+++ b/src/setup/validateTransaction.ts
@@ -17,6 +17,7 @@ import { Utils } from '@shardeum-foundation/lib-types'
 import { ethers } from 'ethers'
 import { shardusConfig } from '..'
 import { validateTransferFromSecureAccount } from '../shardeum/secureAccounts'
+import { isSetCertTimeTx } from '../tx/setCertTime'
 
 type Response = {
   result: string
@@ -66,7 +67,7 @@ export const validateTransaction =
           }
           return { result: 'pass', reason: 'valid' }
         }
-      } else if (tx.internalTXType === InternalTXType.SetCertTime) {
+      } else if (isSetCertTimeTx(tx)) {
         return { result: 'pass', reason: 'valid' }
       } else if (tx.internalTXType === InternalTXType.InitRewardTimes) {
         return InitRewardTimesTx.validate(tx as InitRewardTimes, shardus)

--- a/src/tx/setCertTime.ts
+++ b/src/tx/setCertTime.ts
@@ -23,11 +23,11 @@ import { createInternalTxReceipt, logFlags, shardeumGetTime } from '..'
 import { bigIntToHex, isValidAddress } from '@ethereumjs/util'
 import { Utils } from '@shardeum-foundation/lib-types'
 import { SafeBalance } from '../utils/safeMath'
-import { verify } from '../setup/helpers'
+import { isInternalTx, verify } from '../setup/helpers'
 import { NetworkAccount } from '../types/NetworkAccount';
 
 export function isSetCertTimeTx(tx): boolean {
-  if (tx.isInternalTx && tx.internalTXType === InternalTXType.SetCertTime) {
+  if (isInternalTx(tx) && tx.internalTXType === InternalTXType.SetCertTime) {
     return true
   }
   return false


### PR DESCRIPTION
1 - Only use the isInternalTx function, never use .isInternalTx 
2 - Only use the isSetCertTimeTx function, never compare internelTxType 
3 - Remove the third check from isInternalTx as it is not used