### PR TITLE
SHARD-1926: calculate afterStateHash in init global txs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,11 @@
         "@ethereumjs/util": "9.0.0",
         "@ethereumjs/vm": "7.0.0",
         "@mapbox/node-pre-gyp": "1.0.10",
-        "@shardeum-foundation/core": "2.14.0-prerelease.2",
+        "@shardeum-foundation/core": "2.14.0-prerelease.3",
         "@shardeum-foundation/lib-archiver-discovery": "1.2.0-prerelease.1",
         "@shardeum-foundation/lib-crypto-utils": "4.2.0-prerelease.1",
         "@shardeum-foundation/lib-net": "1.5.0-prerelease.1",
-        "@shardeum-foundation/lib-types": "1.3.0-prerelease.1",
+        "@shardeum-foundation/lib-types": "1.3.0-prerelease.2",
         "@types/sqlite3": "3.1.8",
         "cliffy": "2.5.1",
         "cls-hooked": "4.2.2",
@@ -40,7 +40,7 @@
         "sqlite3": "5.1.6"
       },
       "devDependencies": {
-        "@shardeum-foundation/archiver": "3.6.0-prerelease.2",
+        "@shardeum-foundation/archiver": "3.6.0-prerelease.3",
         "@shardeum-foundation/monitor-server": "2.9.0-prerelease.1",
         "@shardeum-foundation/tools-shardus-cli": "4.4.0-prerelease.0",
         "@types/decimal.js": "7.4.0",
@@ -1990,9 +1990,9 @@
       }
     },
     "node_modules/@shardeum-foundation/archiver": {
-      "version": "3.6.0-prerelease.2",
-      "resolved": "https://registry.npmjs.org/@shardeum-foundation/archiver/-/archiver-3.6.0-prerelease.2.tgz",
-      "integrity": "sha512-TAwM/L5Z7WWFiCUbQI8WoE4B9N8hahn1XBgXUXXMUZ54NPyGPhtFXYDgOalaG8bVNMK9aEKtg4EtjaxQ76tB8w==",
+      "version": "3.6.0-prerelease.3",
+      "resolved": "https://registry.npmjs.org/@shardeum-foundation/archiver/-/archiver-3.6.0-prerelease.3.tgz",
+      "integrity": "sha512-beiIlb38NgtEDpiYStI9+kTcsEfmu7akpKlxv3EYaKZ5vL6mWJiQvhDwSop+GW7hgmA33ME7mwVzeevu38yphg==",
       "dev": true,
       "dependencies": {
         "@ethereumjs/tx": "5.0.0",
@@ -2002,7 +2002,7 @@
         "@shardeum-foundation/lib-archiver-discovery": "1.2.0-prerelease.1",
         "@shardeum-foundation/lib-crypto-utils": "4.2.0-prerelease.1",
         "@shardeum-foundation/lib-net": "1.5.0-prerelease.1",
-        "@shardeum-foundation/lib-types": "1.3.0-prerelease.1",
+        "@shardeum-foundation/lib-types": "1.3.0-prerelease.2",
         "deepmerge": "4.3.1",
         "ethers": "6.13.4",
         "fastify": "4.12.0",
@@ -2077,15 +2077,15 @@
       }
     },
     "node_modules/@shardeum-foundation/core": {
-      "version": "2.14.0-prerelease.2",
-      "resolved": "https://registry.npmjs.org/@shardeum-foundation/core/-/core-2.14.0-prerelease.2.tgz",
-      "integrity": "sha512-e0UrlPuPckgkYHLJlLxloLEueFTGEnXI8Lm0KSzZ3jzGb9nn7dY07XYE6h0OG05HIOvZVVXjkbseCKVtSdaQcQ==",
+      "version": "2.14.0-prerelease.3",
+      "resolved": "https://registry.npmjs.org/@shardeum-foundation/core/-/core-2.14.0-prerelease.3.tgz",
+      "integrity": "sha512-kDYdlrpl94i5yvqoK99B7yUm3ogVC7rqnhDJsTDREI4R+WaXU9gmbA7ZoaGZXt27JrTXOCNOgoFypvjGxTkl5A==",
       "dependencies": {
         "@hapi/sntp": "3.1.1",
         "@mapbox/node-pre-gyp": "1.0.10",
         "@shardeum-foundation/lib-crypto-utils": "4.2.0-prerelease.1",
         "@shardeum-foundation/lib-net": "1.5.0-prerelease.1",
-        "@shardeum-foundation/lib-types": "1.3.0-prerelease.1",
+        "@shardeum-foundation/lib-types": "1.3.0-prerelease.2",
         "@types/better-sqlite3": "7.6.3",
         "body-parser": "1.18.3",
         "bytenode": "1.3.4",
@@ -2447,6 +2447,11 @@
         "node": "18.19.1"
       }
     },
+    "node_modules/@shardeum-foundation/lib-crypto-utils/node_modules/@shardeum-foundation/lib-types": {
+      "version": "1.3.0-prerelease.1",
+      "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-types/-/lib-types-1.3.0-prerelease.1.tgz",
+      "integrity": "sha512-GnWjMWtWij5+HY+nf3l16nYymvTG8HGSH9iw7SNN8bsnyt4UXvty5nhmA6vMvK/zOQzwW+7jsLnMw29RHSiSIg=="
+    },
     "node_modules/@shardeum-foundation/lib-net": {
       "version": "1.5.0-prerelease.1",
       "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-net/-/lib-net-1.5.0-prerelease.1.tgz",
@@ -2461,9 +2466,9 @@
       }
     },
     "node_modules/@shardeum-foundation/lib-types": {
-      "version": "1.3.0-prerelease.1",
-      "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-types/-/lib-types-1.3.0-prerelease.1.tgz",
-      "integrity": "sha512-GnWjMWtWij5+HY+nf3l16nYymvTG8HGSH9iw7SNN8bsnyt4UXvty5nhmA6vMvK/zOQzwW+7jsLnMw29RHSiSIg=="
+      "version": "1.3.0-prerelease.2",
+      "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-types/-/lib-types-1.3.0-prerelease.2.tgz",
+      "integrity": "sha512-+1mZcyrcKjptLtU9qOfVeLkiahxyQu4wfI3WCudpH/adR0FrE80TZlF2gJ+aNkyxf6HTdZ8HNYQd5twZBE6Eqw=="
     },
     "node_modules/@shardeum-foundation/monitor-client": {
       "version": "2.9.0-prerelease.0",

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
   "author": "",
   "dependencies": {
     "@shardeum-foundation/lib-archiver-discovery": "1.2.0-prerelease.1",
-    "@shardeum-foundation/core": "2.14.0-prerelease.2",
+    "@shardeum-foundation/core": "2.14.0-prerelease.3",
     "@shardeum-foundation/lib-crypto-utils": "4.2.0-prerelease.1",
     "@shardeum-foundation/lib-net": "1.5.0-prerelease.1",
-    "@shardeum-foundation/lib-types": "1.3.0-prerelease.1",
+    "@shardeum-foundation/lib-types": "1.3.0-prerelease.2",
     "@ethereumjs/block": "5.0.0",
     "@ethereumjs/blockchain": "7.0.0",
     "@ethereumjs/common": "4.0.0",
@@ -73,7 +73,7 @@
     "sqlite3": "5.1.6"
   },
   "devDependencies": {
-    "@shardeum-foundation/archiver": "3.6.0-prerelease.2",
+    "@shardeum-foundation/archiver": "3.6.0-prerelease.3",
     "@shardeum-foundation/monitor-server": "2.9.0-prerelease.1",
     "@shardeum-foundation/tools-shardus-cli": "4.4.0-prerelease.0",
     "@types/decimal.js": "7.4.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2751,6 +2751,27 @@ const configShardusNetworkTransactions = (): void => {
  *    #### ##    ##    ##    ######## ##     ## ##    ## ##     ## ########       ##    ##     ##
  */
 
+/**
+ * Applies an internal transaction to the given wrapped states and returns an apply response.
+ *
+ * @param tx - The internal transaction to be applied.
+ * @param wrappedStates - The current state of the wrapped accounts.
+ * @param txTimestamp - The timestamp of the transaction.
+ * @returns A promise that resolves to a ShardusTypes.ApplyResponse object.
+ *
+ * The function handles different types of internal transactions:
+ * - `SetGlobalCodeBytes`: Updates the timestamp of the wrapped EVM account and optionally creates an internal transaction receipt.
+ * - `InitNetwork`: Initializes the network account and optionally creates an internal transaction receipt.
+ * - `ChangeConfig`: Schedules a configuration change to be applied at a future cycle and optionally creates an internal transaction receipt.
+ * - `ApplyChangeConfig`: Applies a scheduled configuration change to the network account and optionally creates an internal transaction receipt.
+ * - `ChangeNetworkParam`: Schedules a network parameter change to be applied at a future cycle and optionally creates an internal transaction receipt.
+ * - `ApplyNetworkParam`: Applies a scheduled network parameter change to the network account and optionally creates an internal transaction receipt.
+ * - `SetCertTimeTx`: Applies a certificate time transaction.
+ * - `InitRewardTimes`: Initializes reward times.
+ * - `ClaimReward`: Applies a claim reward transaction.
+ * - `Penalty`: Applies a penalty transaction.
+ * - `TransferFromSecureAccount`: Applies a transfer from a secure account transaction.
+ */
 async function applyInternalTx(
   tx: InternalTx,
   wrappedStates: WrappedStates,
@@ -2870,10 +2891,26 @@ async function applyInternalTx(
 
     // eslint-disable-next-line security/detect-object-injection
     const addressHash = wrappedStates[networkAccount].stateId
+    // eslint-disable-next-line security/detect-object-injection
+
+    // Create a copy of the network account to apply modifications and determine the resulting state.
+    const networkAccountCopy = wrappedStates[networkAccount]
+    networkAccountCopy.data.timestamp = txTimestamp
+    networkAccountCopy.data.listOfChanges.push(internalTx.change)
+    const wrappedChangedAccount = WrappedEVMAccountFunctions._shardusWrappedAccount(networkAccountCopy.data)
+    //value = wrappedChangedAccount
+    const afterStateHash = wrappedChangedAccount.stateId // this is the hash of the network account after it has been modified with a change
 
     const ourAppDefinedData = applyResponse.appDefinedData as OurAppDefinedData
     // network will consens that this is the correct value
-    ourAppDefinedData.globalMsg = { address: networkAccount, addressHash, value, when, source: value.from }
+    ourAppDefinedData.globalMsg = {
+      address: networkAccount,
+      addressHash,
+      value,
+      when,
+      source: value.from,
+      afterStateHash: afterStateHash,
+    }
     if (ShardeumFlags.supportInternalTxReceipt) {
       createInternalTxReceipt(
         shardus,
@@ -2947,11 +2984,26 @@ async function applyInternalTx(
 
     // eslint-disable-next-line security/detect-object-injection
     const addressHash = wrappedStates[networkAccount].stateId
+    // eslint-disable-next-line security/detect-object-injection
+
+    // Create a copy of the network account to apply modifications and determine the resulting state.
+    const networkAccountCopy = wrappedStates[networkAccount]
+    networkAccountCopy.data.timestamp = txTimestamp
+    networkAccountCopy.data.listOfChanges.push(internalTx.change)
+    const wrappedChangedAccount = WrappedEVMAccountFunctions._shardusWrappedAccount(networkAccountCopy.data)
+    //value = wrappedChangedAccount
+    const afterStateHash = wrappedChangedAccount.stateId // this is the hash of the network account after it has been modified with a change
 
     const ourAppDefinedData = applyResponse.appDefinedData as OurAppDefinedData
     // network will consens that this is the correct value
-    ourAppDefinedData.globalMsg = { address: networkAccount, addressHash, value, when, source: value.from }
-
+    ourAppDefinedData.globalMsg = {
+      address: networkAccount,
+      addressHash,
+      value,
+      when,
+      source: value.from,
+      afterStateHash: afterStateHash,
+    }
     if (ShardeumFlags.supportInternalTxReceipt) {
       createInternalTxReceipt(
         shardus,
@@ -3165,9 +3217,17 @@ function setGlobalCodeByteUpdate(
   //value = shardus.signAsNode(value)
 
   const addressHash = WrappedEVMAccountFunctions._calculateAccountHash(wrappedEVMAccount)
+  const afterStateHash = addressHash
 
   const ourAppDefinedData = applyResponse.appDefinedData as OurAppDefinedData
-  ourAppDefinedData.globalMsg = { address: globalAddress, addressHash, value, when, source: globalAddress }
+  ourAppDefinedData.globalMsg = {
+    address: globalAddress,
+    addressHash,
+    value,
+    when,
+    source: globalAddress,
+    afterStateHash: afterStateHash,
+  }
 }
 
 async function _transactionReceiptPass(
@@ -3205,9 +3265,9 @@ async function _transactionReceiptPass(
 
   //If this apply response has a global message defined then call setGlobal()
   if (ourAppDefinedData.globalMsg) {
-    const { address, addressHash, value, when, source } = ourAppDefinedData.globalMsg
+    const { address, addressHash, value, when, source, afterStateHash } = ourAppDefinedData.globalMsg
     //delete value.sign
-    shardus.setGlobal(address, addressHash, value, when, source)
+    shardus.setGlobal(address, addressHash, value, when, source, afterStateHash)
     if (ShardeumFlags.VerboseLogs) {
       const txHash = generateTxId(value)
       console.log(`transactionReceiptPass setglobal: ${txHash} ${Utils.safeStringify(tx)}  `)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3319,7 +3319,7 @@ const getNetworkAccount = async (): Promise<ShardusTypes.WrappedData> => {
   return account
 }
 
-const createNetworkAccount = async (
+export const createNetworkAccount = async (
   accountId: string,
   config: Config,
   isFirstSeed: boolean

--- a/src/index.ts
+++ b/src/index.ts
@@ -2895,8 +2895,8 @@ async function applyInternalTx(
 
     // Create a copy of the network account to apply modifications and determine the resulting state.
     const networkAccountCopy = wrappedStates[networkAccount]
-    networkAccountCopy.data.timestamp = txTimestamp
-    networkAccountCopy.data.listOfChanges.push(internalTx.change)
+    networkAccountCopy.data.timestamp = when
+    networkAccountCopy.data.listOfChanges.push(value.change)
     const wrappedChangedAccount = WrappedEVMAccountFunctions._shardusWrappedAccount(networkAccountCopy.data)
     //value = wrappedChangedAccount
     const afterStateHash = wrappedChangedAccount.stateId // this is the hash of the network account after it has been modified with a change
@@ -2988,8 +2988,8 @@ async function applyInternalTx(
 
     // Create a copy of the network account to apply modifications and determine the resulting state.
     const networkAccountCopy = wrappedStates[networkAccount]
-    networkAccountCopy.data.timestamp = txTimestamp
-    networkAccountCopy.data.listOfChanges.push(internalTx.change)
+    networkAccountCopy.data.timestamp = when
+    networkAccountCopy.data.listOfChanges.push(value.change)
     const wrappedChangedAccount = WrappedEVMAccountFunctions._shardusWrappedAccount(networkAccountCopy.data)
     //value = wrappedChangedAccount
     const afterStateHash = wrappedChangedAccount.stateId // this is the hash of the network account after it has been modified with a change

--- a/src/setup/sync.ts
+++ b/src/setup/sync.ts
@@ -12,7 +12,7 @@ import { ShardeumState, TransactionState } from '../state'
 import * as AccountsStorage from '../storage/accountStorage'
 import { sleep } from '../utils'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
-import { logFlags, shardeumGetTime } from '..'
+import { createNetworkAccount, logFlags, shardeumGetTime } from '..'
 import { Utils } from '@shardeum-foundation/lib-types'
 import { initializeSecureAccount, SecureAccountConfig } from '../shardeum/secureAccounts'
 
@@ -153,13 +153,16 @@ export const sync = (shardus: Shardus, evmCommon: any) => async (): Promise<void
         timestamp: when,
         network: networkAccount,
       }
-      shardus.setGlobal(networkAccount, '', value, when, networkAccount, '') // need to set addressHash = '' because it's not created yet.
-    } else {
+      const wrappedEVMAccount = await createNetworkAccount(networkAccount, config, shardus.p2p.isFirstSeed)
+      wrappedEVMAccount.timestamp = when
+      const wrappedChangedAccount = WrappedEVMAccountFunctions._shardusWrappedAccount(wrappedEVMAccount)
+      const afterStatehash = wrappedChangedAccount.stateId
+      shardus.setGlobal(networkAccount, '', value, when, networkAccount, afterStatehash) // need to set addressHash = '' because it's not created yet.
+    } else
       while (!(await shardus.getLocalOrRemoteAccount(networkAccount))) {
         /* prettier-ignore */ if (logFlags.important_as_error) console.log('waiting..')
         await sleep(1000)
       }
-    }
   }
 }
 

--- a/src/setup/sync.ts
+++ b/src/setup/sync.ts
@@ -153,7 +153,7 @@ export const sync = (shardus: Shardus, evmCommon: any) => async (): Promise<void
         timestamp: when,
         network: networkAccount,
       }
-      shardus.setGlobal(networkAccount, '', value, when, networkAccount) // need to set addressHash = '' because it's not created yet.
+      shardus.setGlobal(networkAccount, '', value, when, networkAccount, '') // need to set addressHash = '' because it's not created yet.
     } else {
       while (!(await shardus.getLocalOrRemoteAccount(networkAccount))) {
         /* prettier-ignore */ if (logFlags.important_as_error) console.log('waiting..')

--- a/src/shardeum/shardeumTypes.ts
+++ b/src/shardeum/shardeumTypes.ts
@@ -285,6 +285,7 @@ export interface OurAppDefinedData {
     }
     when: number
     source: string
+    afterStateHash: string
   }
 }
 


### PR DESCRIPTION
### 🚨 Summary  
[SHARD-1926 — Malicious Validator Can Modify `txId` in Global Transactions](https://linear.app/shm/issue/SHARD-1926/[bb]-39893-malicious-validator-can-modify-txid-in-global-transactions)

This PR resolves a critical security vulnerability in how the archiver validates Global Transaction Receipts.

Global transactions submitted to the archiver include a `tx` object that is **not cryptographically verified**. As a result, malicious validators can alter the `txId`, `timestamp`, and even the `afterStates` without invalidating the receipt.

This flaw enables two types of attacks:
1. **Transaction censorship** — by hijacking a `txId`, future valid submissions are rejected.
2. **State corruption** — by modifying `afterStates`, attackers can inject or alter accounts arbitrarily.

---

### ⚠️ Root Cause  
- The `verifyAppliedReceiptSignatures()` function extracts the `tx` object from `receipt.signedReceipt`, but **does not validate its integrity**.
- Unlike `beforeStates` and `afterStates`, which are separately validated in `verifyGlobalTxAccountChange()`, the core `tx` payload—including `txId` and other metadata—is trusted without recomputation or comparison.
- The current logic assumes that the signed receipt's internal `tx` is trustworthy, without enforcing consistency with the actual signature.
