### PR TITLE
SHARD-2060: revert previous changes to `isInternalTx` to accomodate for internalTxs that are passed in as timestampedTxs

### DIFF
--- a/src/setup/helpers.ts
+++ b/src/setup/helpers.ts
@@ -32,6 +32,7 @@ export function isInternalTXGlobal(internalTx: InternalTx): boolean {
 export function isInternalTx(timestampedTx: any): boolean {
   if (timestampedTx && timestampedTx.raw) return false
   if (timestampedTx && timestampedTx.isInternalTx) return true
+  if (timestampedTx?.tx?.isInternalTx) return true
   return false
 }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Revert previous changes to `isInternalTx` function.

- Accommodate `internalTx` passed as `timestampedTx`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.ts</strong><dd><code>Fix `isInternalTx` function for nested transactions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/setup/helpers.ts

<li>Reverted changes to <code>isInternalTx</code> function.<br> <li> Added check for <code>timestampedTx?.tx?.isInternalTx</code>.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/412/files#diff-01001845d1ad6bb0f091e718516d89f88df0dbb7881952b23d986770339416c2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>