### PR TITLE
SHARD-2241 - Update accounts

### DIFF
--- a/src/config/genesis-secure-accounts.json
+++ b/src/config/genesis-secure-accounts.json
@@ -2,28 +2,28 @@
   {
     "Name": "Foundation",
     "SourceFundsAddress": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "RecipientFundsAddress": "0xf08b4a82ef3ad9c919852a3d32eb5088af9a9153",
+    "RecipientFundsAddress": "0x31B8942433BD3f0A4C62EF1F2Af06F47C1dD8c32",
     "SecureAccountAddress": "1111111111111111111111111111111111111111000000000000000000000000",
     "SourceFundsBalance": "55878999000000000000000000"
   },
   {
     "Name": "Team",
     "SourceFundsAddress": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    "RecipientFundsAddress": "0xde368dce1070dba428b8133265666261ddca9f1a",
+    "RecipientFundsAddress": "0x5Bc620affd7F320297115Ee2D3dC0AF319a1B566",
     "SecureAccountAddress": "2222222222222222222222222222222222222222000000000000000000000000",
     "SourceFundsBalance": "76200000000000000000000000"
   },
   {
     "Name": "Ecosystem",
     "SourceFundsAddress": "0xcccccccccccccccccccccccccccccccccccccccc",
-    "RecipientFundsAddress": "0x2cf747f34a61bd23a7cff6974e56012fbc193b7e",
+    "RecipientFundsAddress": "0x629c55985931fE425e3439145D8A3d0aAf42F4E3",
     "SecureAccountAddress": "3333333333333333333333333333333333333333000000000000000000000000",
     "SourceFundsBalance": "21054025000000000000000000"
   },
   {
     "Name": "Sale",
     "SourceFundsAddress": "0xdddddddddddddddddddddddddddddddddddddddd",
-    "RecipientFundsAddress": "0x051b7b30e828ea8c371019e94aea28cdbef47ff8",
+    "RecipientFundsAddress": "0xFa2004E50e721897095cB606861b0Dc7AC130dE9",
     "SecureAccountAddress": "4444444444444444444444444444444444444444000000000000000000000000",
     "SourceFundsBalance": "91440000000000000000000000"
   }

--- a/src/config/mainnet.genesis-secure-accounts.json
+++ b/src/config/mainnet.genesis-secure-accounts.json
@@ -2,28 +2,28 @@
   {
     "Name": "Foundation",
     "SourceFundsAddress": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "RecipientFundsAddress": "0xf08b4a82ef3ad9c919852a3d32eb5088af9a9153",
+    "RecipientFundsAddress": "0x31B8942433BD3f0A4C62EF1F2Af06F47C1dD8c32",
     "SecureAccountAddress": "1111111111111111111111111111111111111111000000000000000000000000",
     "SourceFundsBalance": "55878999000000000000000000"
   },
   {
     "Name": "Team",
     "SourceFundsAddress": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    "RecipientFundsAddress": "0xde368dce1070dba428b8133265666261ddca9f1a",
+    "RecipientFundsAddress": "0x5Bc620affd7F320297115Ee2D3dC0AF319a1B566",
     "SecureAccountAddress": "2222222222222222222222222222222222222222000000000000000000000000",
     "SourceFundsBalance": "76200000000000000000000000"
   },
   {
     "Name": "Ecosystem",
     "SourceFundsAddress": "0xcccccccccccccccccccccccccccccccccccccccc",
-    "RecipientFundsAddress": "0x2cf747f34a61bd23a7cff6974e56012fbc193b7e",
+    "RecipientFundsAddress": "0x629c55985931fE425e3439145D8A3d0aAf42F4E3",
     "SecureAccountAddress": "3333333333333333333333333333333333333333000000000000000000000000",
     "SourceFundsBalance": "21054025000000000000000000"
   },
   {
     "Name": "Sale",
     "SourceFundsAddress": "0xdddddddddddddddddddddddddddddddddddddddd",
-    "RecipientFundsAddress": "0x051b7b30e828ea8c371019e94aea28cdbef47ff8",
+    "RecipientFundsAddress": "0xFa2004E50e721897095cB606861b0Dc7AC130dE9",
     "SecureAccountAddress": "4444444444444444444444444444444444444444000000000000000000000000",
     "SourceFundsBalance": "91440000000000000000000000"
   }

--- a/src/config/stagenet.genesis-secure-accounts.json
+++ b/src/config/stagenet.genesis-secure-accounts.json
@@ -2,28 +2,28 @@
   {
     "Name": "Foundation",
     "SourceFundsAddress": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "RecipientFundsAddress": "0x7Efbb31431ac7C405E8eEba99531fF1254fCA3B6",
+    "RecipientFundsAddress": "0x1238ce53F6C4Ca928B4ca9f1229681Cf4C65351e",
     "SecureAccountAddress": "1111111111111111111111111111111111111111000000000000000000000000",
     "SourceFundsBalance": "15862951000000000000000000"
   },
   {
     "Name": "Team",
     "SourceFundsAddress": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    "RecipientFundsAddress": "0xCc74bf387F6C102b5a7F828796C57A6D2D19Cb00",
+    "RecipientFundsAddress": "0x6ee00b7b8e9ccDa6d779AEf27DAB81697cf99424",
     "SecureAccountAddress": "2222222222222222222222222222222222222222000000000000000000000000",
     "SourceFundsBalance": "76200000000000000000000000"
   },
   {
     "Name": "Ecosystem",
     "SourceFundsAddress": "0xcccccccccccccccccccccccccccccccccccccccc",
-    "RecipientFundsAddress": "0x4ed5C053BF2dA5F694b322EA93dce949F3276B85",
+    "RecipientFundsAddress": "0x8265739942248fC0F44bA1CD97D9390B93039015",
     "SecureAccountAddress": "3333333333333333333333333333333333333333000000000000000000000000",
     "SourceFundsBalance": "21054025000000000000000000"
   },
   {
     "Name": "Sale",
     "SourceFundsAddress": "0xdddddddddddddddddddddddddddddddddddddddd",
-    "RecipientFundsAddress": "0xd31aBC7497aD8bC9fe8555C9eDe45DFd7FB3Bf6F",
+    "RecipientFundsAddress": "0x9AdB18291Aef09f9E315e836d2ed0279fE8E4EE8",
     "SecureAccountAddress": "4444444444444444444444444444444444444444000000000000000000000000",
     "SourceFundsBalance": "91440000000000000000000000"
   }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated `RecipientFundsAddress` for all major accounts

- Applied changes to both genesis and mainnet config files

- Ensured consistency across secure account configurations

- No changes to balances or source addresses


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>genesis-secure-accounts.json</strong><dd><code>Update recipient addresses in genesis secure accounts config</code></dd></summary>
<hr>

src/config/genesis-secure-accounts.json

<li>Updated <code>RecipientFundsAddress</code> for Foundation, Team, Ecosystem, and <br>Sale accounts<br> <li> No changes to balances or other fields<br> <li> Ensured secure account addresses remain unchanged


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/461/files#diff-0824cd7c57b8e7f345a24057c52b234c85d5bed6d2ca121d215ea49b9f601cda">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mainnet.genesis-secure-accounts.json</strong><dd><code>Update recipient addresses in mainnet secure accounts config</code></dd></summary>
<hr>

src/config/mainnet.genesis-secure-accounts.json

<li>Updated <code>RecipientFundsAddress</code> for Foundation, Team, Ecosystem, and <br>Sale accounts<br> <li> Maintained consistency with genesis config updates<br> <li> No modifications to balances or source addresses


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/461/files#diff-1e2489838ce4ec1a25b6bad6f6471a776768f9d0467f02c920dfd95669422e3d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>