### PR TITLE
SHARD-2275 : add debug endpoints for core flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2095,7 +2095,7 @@
         "got": "11.8.6",
         "log4js": "6.9.1",
         "log4js-extend": "0.2.1",
-        "nat-api": "timadinorth/nat-api#appsec-dep-fix",
+        "nat-api": "github:timadinorth/nat-api#appsec-dep-fix",
         "neverthrow": "6.0.0",
         "rfdc": "1.4.1",
         "socket.io": "2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@ethereumjs/util": "9.0.0",
         "@ethereumjs/vm": "7.0.0",
         "@mapbox/node-pre-gyp": "1.0.10",
-        "@shardeum-foundation/core": "2.14.0-prerelease.14",
+        "@shardeum-foundation/core": "git+https://github.com/shardeum/shardus-core#chaos-testing",
         "@shardeum-foundation/lib-archiver-discovery": "1.2.0-prerelease.4",
         "@shardeum-foundation/lib-crypto-utils": "4.2.0-prerelease.4",
         "@shardeum-foundation/lib-net": "1.5.0-prerelease.2",
@@ -2079,8 +2079,7 @@
     },
     "node_modules/@shardeum-foundation/core": {
       "version": "2.14.0-prerelease.14",
-      "resolved": "https://registry.npmjs.org/@shardeum-foundation/core/-/core-2.14.0-prerelease.14.tgz",
-      "integrity": "sha512-fH5y+WA7SuqCivAyFKBANj6PgOeX7A49d6gDis0bEEscWWZV1yVPoZB/3AEmiFU6r54fWGtFAWKl+mhIyyniPA==",
+      "resolved": "git+ssh://git@github.com/shardeum/shardus-core.git#964d07a48490041feb532d1036ffd7a1a64eff03",
       "dependencies": {
         "@hapi/sntp": "3.1.1",
         "@mapbox/node-pre-gyp": "1.0.10",
@@ -2096,7 +2095,7 @@
         "got": "11.8.6",
         "log4js": "6.9.1",
         "log4js-extend": "0.2.1",
-        "nat-api": "github:timadinorth/nat-api#appsec-dep-fix",
+        "nat-api": "timadinorth/nat-api#appsec-dep-fix",
         "neverthrow": "6.0.0",
         "rfdc": "1.4.1",
         "socket.io": "2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@ethereumjs/util": "9.0.0",
         "@ethereumjs/vm": "7.0.0",
         "@mapbox/node-pre-gyp": "1.0.10",
-        "@shardeum-foundation/core": "git+https://github.com/shardeum/shardus-core#chaos-testing",
+        "@shardeum-foundation/core": "git+https://github.com/shardeum/core#chaos-testing",
         "@shardeum-foundation/lib-archiver-discovery": "1.2.0-prerelease.4",
         "@shardeum-foundation/lib-crypto-utils": "4.2.0-prerelease.4",
         "@shardeum-foundation/lib-net": "1.5.0-prerelease.2",
@@ -2079,7 +2079,7 @@
     },
     "node_modules/@shardeum-foundation/core": {
       "version": "2.14.0-prerelease.14",
-      "resolved": "git+ssh://git@github.com/shardeum/shardus-core.git#964d07a48490041feb532d1036ffd7a1a64eff03",
+      "resolved": "git+ssh://git@github.com/shardeum/core.git#964d07a48490041feb532d1036ffd7a1a64eff03",
       "dependencies": {
         "@hapi/sntp": "3.1.1",
         "@mapbox/node-pre-gyp": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "author": "",
   "dependencies": {
     "@shardeum-foundation/lib-archiver-discovery": "1.2.0-prerelease.4",
-    "@shardeum-foundation/core": "2.14.0-prerelease.14",
+    "@shardeum-foundation/core": "git+https://github.com/shardeum/shardus-core#chaos-testing",
     "@shardeum-foundation/lib-crypto-utils": "4.2.0-prerelease.4",
     "@shardeum-foundation/lib-net": "1.5.0-prerelease.2",
     "@shardeum-foundation/lib-types": "1.3.0-prerelease.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "author": "",
   "dependencies": {
     "@shardeum-foundation/lib-archiver-discovery": "1.2.0-prerelease.4",
-    "@shardeum-foundation/core": "git+https://github.com/shardeum/shardus-core#chaos-testing",
+    "@shardeum-foundation/core": "git+https://github.com/shardeum/core#chaos-testing",
     "@shardeum-foundation/lib-crypto-utils": "4.2.0-prerelease.4",
     "@shardeum-foundation/lib-net": "1.5.0-prerelease.2",
     "@shardeum-foundation/lib-types": "1.3.0-prerelease.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1712,6 +1712,94 @@ const configShardusEndpoints = (): void => {
       res.json(`debug-set-shardeum-flag: ${key} ${err.message} `)
     }
   })
+
+  // Register an external GET endpoint for fetching core flags
+  shardus.registerExternalGet('debug-core-flags', debugMiddleware, async (req, res) => {
+    try {
+      // Fetch the core flags from shardus
+      const CoreFlags = shardus.fetchCoreFlags()
+      // Respond with the fetched core flags
+      res.json({ CoreFlags })
+    } catch (e) {
+      // Log an error if fetching core flags fails
+      /* prettier-ignore */ if (logFlags.error) console.log("Problem fetching shardus-core flags", e)
+      // Respond with an error message
+      res.json({ error: e.message })
+    }
+  })
+
+  // Register an external GET endpoint for setting a core flag
+  shardus.registerExternalGet('debug-set-core-flag', debugMiddleware, async (req, res) => {
+    // Check if debug flags are enabled in the configuration
+    if (!shardusConfig.debug.enableDebugFlags) {
+      // Respond with an error if debug flags are not enabled
+      res.json({ error: 'debug flags are not enabled' })
+      return
+    }
+    let value
+    let key
+    try {
+      // Extract key and value from the request query
+      key = req.query.key as string
+      value = req.query.value as string
+      // Check if key or value is null
+      if (key == null || value == null) {
+        // Respond with an error if key or value is null
+        res.json(`debug-set-core-flag: key/value == null`)
+        return
+      }
+
+      let typedValue: boolean | number | string
+
+      // Determine the value type first
+      let valueType // No default type
+
+      // Determine the type of the value
+      if (value === 'true' || value === 'false') {
+        valueType = 'boolean'
+      } else if (!Number.isNaN(Number(value)) && value.trim() !== '') {
+        valueType = 'number'
+      } else if (typeof value === 'string') {
+        valueType = 'string'
+      } else {
+        valueType = 'other'
+      }
+
+      // Use switch case on the determined type
+      switch (valueType) {
+        case 'boolean':
+          // Convert value to boolean
+          typedValue = value === 'true'
+          break
+        case 'number':
+          // Convert value to number
+          typedValue = Number(value)
+          break
+        case 'string':
+          // Keep value as string
+          typedValue = String(value)
+          break
+        default:
+          // Handle any other type
+          /* prettier-ignore */ if (logFlags.error) console.log(`Invalid value type encountered`, value)
+          // Respond with an error if the value type is invalid
+          res.json({ error: `Invalid value type encountered` })
+          return
+      }
+
+      // Update the core flag with the key and typed value
+      shardus.updateCoreFlag(key, typedValue)
+
+      // Respond with the updated key and value
+      res.json({ [key]: typedValue })
+    } catch (err) {
+      // Log an error if setting the core flag fails
+      /* prettier-ignore */ if (logFlags.error) console.log(`Problem setting core flag in debug-set-core-flag`, err)
+      // Respond with an error message
+      res.json(`debug-set-core-flag: ${key} ${err.message} `)
+    }
+  })
+
   shardus.registerExternalGet('debug-set-service-point', debugMiddleware, async (req, res) => {
     let value
     let key1


### PR DESCRIPTION
### **User description**
Adds external GET endpoints to fetch and set core flags for debugging purposes.

This allows developers to dynamically adjust and inspect core flags, facilitating easier testing and troubleshooting. Includes type validation for setting flag values and error handling.

linear : https://linear.app/shm/issue/SHARD-2275/port-shardeumflags-concept-to-a-generic-feature-localflags-that-will


___

### **PR Type**
Enhancement


___

### **Description**
- Add external GET endpoint to fetch core flags for debugging

- Add external GET endpoint to set core flags with type validation

- Implement error handling and logging for new endpoints

- Restrict core flag modification to when debug flags are enabled


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add debug endpoints for core flag fetch and set</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.ts

<li>Added <code>debug-core-flags</code> endpoint to fetch core flags via GET<br> <li> Added <code>debug-set-core-flag</code> endpoint to set core flags with type <br>validation<br> <li> Implemented error handling and logging for both endpoints<br> <li> Restricted core flag setting to when debug flags are enabled in config


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/476/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+88/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>