### PR TITLE
SHARD-2304: Pass in the nominee account data to isStakeUnlocked check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1571,13 +1571,19 @@ const configShardusEndpoints = (): void => {
     try {
       const nominator = await getAccountData(shardus, req.params['nominator'], { query: {} })
       const nominatee = await getAccountData(shardus, req.params['nominee'], { query: { type: 9 } })
-      if (nominatee == null || nominator == null || nominator.account == null || nominatee.account == null) {
+      if (
+        nominatee == null ||
+        nominator == null ||
+        nominator.account == null ||
+        nominatee.account == null ||
+        nominatee.account.data == null
+      ) {
         res.json({ error: 'account not found' })
         return
       }
       const stakeUnlocked = isStakeUnlocked(
         nominator.account,
-        nominatee.account,
+        nominatee.account.data,
         shardus,
         AccountsStorage.cachedNetworkAccount,
         false // Explicitly check node states in the canUnstake endpoint


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Pass nominee account data, not full account, to `isStakeUnlocked`

- Add null check for `nominee.account.data` before proceeding

- Improve error handling for missing nominee account data


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Refine nominee data handling in unstake endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.ts

<li>Add null check for <code>nominee.account.data</code> before stake check<br> <li> Pass <code>nominee.account.data</code> to <code>isStakeUnlocked</code> instead of full account<br> <li> Improve error response for missing nominee data


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/478/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>