### PR TITLE
SHARD-2304: Fix re-stake reason msg

### DIFF
--- a/src/tx/staking/verifyStake.ts
+++ b/src/tx/staking/verifyStake.ts
@@ -320,7 +320,7 @@ export function isRestakingAllowed(
   const restakeAllowed = remainingTime <= 0
   return {
     restakeAllowed,
-    reason,
+    reason: restakeAllowed ? '' : reason,
     remainingTime,
   }
 }


### PR DESCRIPTION
### **User description**
The restake reason message mistakenly indicates that restaking is not permitted yet, which may cause confusion.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes restake reason message logic for clarity

- Ensures empty reason when restaking is allowed

- Prevents confusing messages for allowed restakes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verifyStake.ts</strong><dd><code>Correct restake reason message logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tx/staking/verifyStake.ts

<li>Updates logic to set empty reason if restaking is allowed<br> <li> Prevents displaying misleading messages when restaking is permitted


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/479/files#diff-535052d2715b8eef31b43450b02a05dc4598c36bc60d6a6998d2f7a9a68a2e26">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>