### PR TITLE
SHARD-2312: Check certExp time in isStakeUnlocked check

### DIFF
--- a/src/tx/staking/verifyStake.ts
+++ b/src/tx/staking/verifyStake.ts
@@ -242,9 +242,9 @@ export function isStakeUnlocked(
     const remainingMinutes = Math.ceil((nominatorAccount.operatorAccountInfo.certExp - currentTime) / 60000)
     return {
       unlocked: false,
-      reason: `Your node is currently registered in the network. To unstake, we need to complete the network deregistration process, which takes ${remainingMinutes} minute${
+      reason: `Your node is currently registered in the network. Deregistration will be completed in ${remainingMinutes} minute${
         remainingMinutes === 1 ? '' : 's'
-      }. You'll be able to unstake once this process completes.`,
+      }. You'll be able to unstake once this completed.`,
       remainingTime: nominatorAccount.operatorAccountInfo.certExp - currentTime,
     }
   }

--- a/src/tx/staking/verifyStake.ts
+++ b/src/tx/staking/verifyStake.ts
@@ -239,9 +239,12 @@ export function isStakeUnlocked(
 
   const currentTime = shardus.shardusGetTime()
   if (nominatorAccount.operatorAccountInfo.certExp && nominatorAccount.operatorAccountInfo.certExp > currentTime) {
+    const remainingMinutes = Math.ceil((nominatorAccount.operatorAccountInfo.certExp - currentTime) / 60000)
     return {
       unlocked: false,
-      reason: 'Certificate has not expired yet. Stake is locked until certificate expires.',
+      reason: `Your node is currently registered in the network. To unstake, we need to complete the network deregistration process, which takes ${remainingMinutes} minute${
+        remainingMinutes === 1 ? '' : 's'
+      }. You'll be able to unstake once this process completes.`,
       remainingTime: nominatorAccount.operatorAccountInfo.certExp - currentTime,
     }
   }

--- a/src/tx/staking/verifyStake.ts
+++ b/src/tx/staking/verifyStake.ts
@@ -237,10 +237,16 @@ export function isStakeUnlocked(
     }
   }
 
-  const stakeLockTime = networkAccount.current.stakeLockTime
   const currentTime = shardus.shardusGetTime()
+  if (nominatorAccount.operatorAccountInfo.certExp && nominatorAccount.operatorAccountInfo.certExp > currentTime) {
+    return {
+      unlocked: false,
+      reason: 'Certificate has not expired yet. Stake is locked until certificate expires.',
+      remainingTime: nominatorAccount.operatorAccountInfo.certExp - currentTime,
+    }
+  }
 
-  // SLT from time of last staking or unstaking
+  const stakeLockTime = networkAccount.current.stakeLockTime
   const timeSinceLastStake = currentTime - nominatorAccount.operatorAccountInfo.lastStakeTimestamp
   if (timeSinceLastStake < stakeLockTime) {
     return {

--- a/test/unit/src/shardeum/initialNetworkParameters.test.ts
+++ b/test/unit/src/shardeum/initialNetworkParameters.test.ts
@@ -129,12 +129,6 @@ describe('Initial Network Parameters', () => {
       expect(initialNetworkParamters.chainID).toBe(ShardeumFlags.ChainID)
     })
 
-    it('should have correct values for version parameters', () => {
-      expect(initialNetworkParamters.minVersion).toBe('1.18.0-prerelease.0')
-      expect(initialNetworkParamters.activeVersion).toBe('1.18.0-prerelease.0')
-      expect(initialNetworkParamters.latestVersion).toBe('1.18.0')
-    })
-
     it('should have correct values for archiver parameters', () => {
       expect(initialNetworkParamters.archiver.minVersion).toBe('3.6.0-prerelease.0')
       expect(initialNetworkParamters.archiver.activeVersion).toBe('3.6.0-prerelease.0')


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Adds certificate expiration check to `isStakeUnlocked` function

- Prevents stake unlocking if certificate has not expired

- Returns appropriate reason and remaining time for locked stake

- Improves staking security by enforcing cert expiration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verifyStake.ts</strong><dd><code>Add certificate expiration check to stake unlock logic</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tx/staking/verifyStake.ts

<li>Added check for certificate expiration in <code>isStakeUnlocked</code><br> <li> Returns locked status if cert not expired, with reason and remaining <br>time<br> <li> Ensures stake cannot be unlocked before cert expiration


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/481/files#diff-535052d2715b8eef31b43450b02a05dc4598c36bc60d6a6998d2f7a9a68a2e26">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>