### PR TITLE
SHARD-2455 - Adjust testnet genesis config for reset

### DIFF
--- a/environments/testnet.config.json
+++ b/environments/testnet.config.json
@@ -1,16 +1,16 @@
 {
   "server": {
     "p2p": {
-      "baselineNodes": 200,
-      "minNodes": 200,
+      "baselineNodes": 20,
+      "minNodes": 20,
       "maxNodes": 1280,
       "syncingDesiredMinCount": 5,
       "flexibleRotationDelta": 4,
-      "formingNodesPerCycle": 200,
+      "formingNodesPerCycle": 20,
       "allowEndUserTxnInjections": true
     },
     "sharding": {
-      "nodesPerConsensusGroup": 32
+      "nodesPerConsensusGroup": 10
     },
     "mode": "debug",
     "debug": {


### PR DESCRIPTION
### **User description**
We plan to run a smaller testnet moving forward.


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Reduced testnet node counts for a smaller testnet

- Lowered consensus group size and forming nodes per cycle

- Updated max nodes and baseline/min nodes in P2P config

- Prepares environment for a scaled-down testnet reset


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>testnet.config.json</strong><dd><code>Reduce node and consensus group counts in testnet config</code>&nbsp; </dd></summary>
<hr>

environments/testnet.config.json

<li>Decreased <code>baselineNodes</code>, <code>minNodes</code>, and <code>maxNodes</code> in P2P config<br> <li> Lowered <code>formingNodesPerCycle</code> and <code>nodesPerConsensusGroup</code><br> <li> Adjusted configuration for a smaller testnet deployment


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/497/files#diff-3e342edcba5fb03899a724416af711e17ec5ae210041cac822eed0561dacbfbe">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>