### PR TITLE
Fix validateSetCertTimeState missing account

### DIFF
--- a/src/tx/setCertTime.ts
+++ b/src/tx/setCertTime.ts
@@ -116,20 +116,19 @@ export function validateSetCertTimeState(
 ): { result: string; reason: string } {
   let committedStake = BigInt(0)
 
-  let operatorEVMAccount: WrappedEVMAccount
-  const acct = wrappedStates[toShardusAddress(tx.nominator, AccountType.Account)].data
+  let operatorEVMAccount: WrappedEVMAccount | undefined
+  const acct = wrappedStates[toShardusAddress(tx.nominator, AccountType.Account)]?.data
   if (WrappedEVMAccountFunctions.isWrappedEVMAccount(acct)) {
     operatorEVMAccount = acct
+    fixDeserializedWrappedEVMAccount(operatorEVMAccount)
   }
-  fixDeserializedWrappedEVMAccount(operatorEVMAccount)
   /* prettier-ignore */ if (logFlags.dapp_verbose) console.log('validateSetCertTimeState', tx, operatorEVMAccount)
   if (operatorEVMAccount == undefined) {
     /* prettier-ignore */ if (logFlags.dapp_verbose) console.log(`setCertTime validate state: found no wrapped state for operator account ${tx.nominator}`)
-    if (ShardeumFlags.fixCertExpTiming)
-      return {
-        result: 'fail',
-        reason: `Found no wrapped state for operator account ${tx.nominator}`,
-      }
+    return {
+      result: 'fail',
+      reason: `Found no wrapped state for operator account ${tx.nominator}`,
+    }
   } else {
     const transactionNominee = tx.nominee
     const operatorNominee = operatorEVMAccount.operatorAccountInfo.nominee

--- a/test/unit/src/tx/setCertTime.test.ts
+++ b/test/unit/src/tx/setCertTime.test.ts
@@ -319,19 +319,14 @@ describe('setCertTime', () => {
             expect(result.reason).toBe('valid')
         })
 
-        // TODO: Potentially a bug. validateSetCertTimeState() is not able to handle the 
-        // edge case wrapped states does not have the operator account. Even if the passed wrapped
-        // states array is supposed to have all accounts, the validateSetCertTimeState function should be 
-        // able to handle the case where the operator account is not found. Currently it will just break
-
-        // it('should reject when operator account is not found', () => {
-        //     const states = { ...mockWrappedStates }
-        //     const operatorAddress = toShardusAddress(validTx.nominator, AccountType.Account)
-        //     delete states[operatorAddress]
-        //     const result = validateSetCertTimeState(validTx, states)
-        //     expect(result.result).toBe('fail')
-        //     expect(result.reason).toContain('Found no wrapped state for operator account')
-        // })
+        it('should reject when operator account is not found', () => {
+            const states = { ...mockWrappedStates }
+            const operatorAddress = toShardusAddress(validTx.nominator, AccountType.Account)
+            delete states[operatorAddress]
+            const result = validateSetCertTimeState(validTx, states)
+            expect(result.result).toBe('fail')
+            expect(result.reason).toContain('Found no wrapped state for operator account')
+        })
 
         it('should reject when nominee mismatch', () => {
             const tx = { ...validTx, nominee: '0x9999' }


### PR DESCRIPTION
### **User description**
## Summary
- handle missing operator account in validateSetCertTimeState
- add regression test for missing operator account

## Testing
- `npm test` *(fails: Cannot find global type 'Array')*


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix `validateSetCertTimeState` to handle missing operator account

- Remove dependency on `ShardeumFlags.fixCertExpTiming` for this check

- Re-enable and update regression test for missing operator account

- Improve robustness of state validation logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setCertTime.ts</strong><dd><code>Robust handling for missing operator account in validation</code></dd></summary>
<hr>

src/tx/setCertTime.ts

<li>Update logic to safely handle missing operator account in state<br> <li> Remove conditional on <code>ShardeumFlags.fixCertExpTiming</code> for failure case<br> <li> Ensure function always returns fail if operator account is missing<br> <li> Minor refactoring for clarity and robustness


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/500/files#diff-801f96452344614d27069c631ad031a8fb1eca5974d2971e1acbc71bdb318c9c">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setCertTime.test.ts</strong><dd><code>Re-enable and update regression test for missing operator account</code></dd></summary>
<hr>

test/unit/src/tx/setCertTime.test.ts

<li>Re-enable and update test for missing operator account scenario<br> <li> Ensure test expects failure with correct error message<br> <li> Remove outdated comments about known bug


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/500/files#diff-a360f11356e1dadca8c587fcbc96f2c69966265d4b75a1f6081448cfd51287e0">+8/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>