### PR TITLE
Use LRU cache for per-tx state

### DIFF
--- a/src/debug/evmSetup/index.ts
+++ b/src/debug/evmSetup/index.ts
@@ -3,6 +3,7 @@ import { ShardeumFlags } from '../../shardeum/shardeumFlags'
 import { ShardeumBlock } from '../block/blockchain'
 import { VM } from '../../vm_v7/vm'
 import { ShardeumState } from '../state'
+import { LRUCache } from 'lru-cache'
 import { EVMAccountInfo } from '../../shardeum/shardeumTypes'
 import { ShardusTypes } from '@shardeum-foundation/core'
 import { EVM as EthereumVirtualMachine } from '../../evm_v2'
@@ -10,7 +11,7 @@ import { EVM as EthereumVirtualMachine } from '../../evm_v2'
 let shardeumBlock: ShardeumBlock
 export let evmCommon: Common
 export let EVM: { -readonly [P in keyof VM] }
-export let shardeumStateTXMap: Map<string, ShardeumState>
+export let shardeumStateTXMap: LRUCache<string, ShardeumState>
 export let shardusAddressToEVMAccountInfo: Map<string, EVMAccountInfo>
 export let debugAppdata: Map<string, unknown>
 
@@ -84,8 +85,11 @@ export async function initEVMSingletons(): Promise<void> {
   //todo need to evict old data
   ////transactionStateMap = new Map<string, TransactionState>()
 
-  // a map of txID or ethcallID to shardeumState, todo need to evict old data
-  shardeumStateTXMap = new Map<string, ShardeumState>()
+  // a map of txID or ethcallID to shardeumState
+  shardeumStateTXMap = new LRUCache<string, ShardeumState>({
+    max: 1000,
+    ttl: 60_000,
+  })
   // a map of txID or ethcallID to shardeumState, todo need to evict old data
   //shardeumStateCallMap = new Map<string, ShardeumState>()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { EVMResult } from './evm_v2/types'
 import { Response as GotResponse } from 'got'
 import 'dotenv/config'
 import { ShardeumState, TransactionState } from './state'
+import { LRUCache } from 'lru-cache'
 import {
   __ShardFunctions,
   nestedCountersInstance,
@@ -510,7 +511,7 @@ let shardeumBlock: ShardeumBlock
 //let transactionStateMap:Map<string, TransactionState>
 
 //Per TX or Eth call shardeum State.  Note the key is the shardus transaction id
-let shardeumStateTXMap: Map<string, ShardeumState>
+let shardeumStateTXMap: LRUCache<string, ShardeumState>
 //let shardeumStateCallMap:Map<string, ShardeumState>
 //let shardeumStatePool:ShardeumState[]
 // const debugShardeumState: ShardeumState = null
@@ -564,8 +565,11 @@ async function initEVMSingletons(): Promise<void> {
   //todo need to evict old data
   ////transactionStateMap = new Map<string, TransactionState>()
 
-  // a map of txID or ethcallID to shardeumState, todo need to evict old data
-  shardeumStateTXMap = new Map<string, ShardeumState>()
+  // a map of txID or ethcallID to shardeumState
+  shardeumStateTXMap = new LRUCache<string, ShardeumState>({
+    max: 1000,
+    ttl: 60_000,
+  })
   // a map of txID or ethcallID to shardeumState, todo need to evict old data
   //shardeumStateCallMap = new Map<string, ShardeumState>()
 
@@ -8211,21 +8215,6 @@ const shardusSetup = (): void => {
   shardus.registerExceptionHandler()
 }
 
-//Note, this functionality was disabled 10 months ago.
-//now that we are moving away from TX expiration we would need to be safe if we ever
-//turn this back on.  (note, disabled by having setTimeout not called again)
-function periodicMemoryCleanup(): void {
-  const keys = shardeumStateTXMap.keys()
-  //todo any provisions needed for TXs that can hop and extend the timer
-  const maxAge = shardeumGetTime() - 60000
-  for (const key of keys) {
-    const shardeumState = shardeumStateTXMap.get(key)
-    if (shardeumState._transactionState.createdTimestamp < maxAge) {
-      shardeumStateTXMap.delete(key)
-    }
-  }
-  // setTimeout(periodicMemoryCleanup, 60000)
-}
 
 async function fetchNetworkAccountFromArchiver(): Promise<WrappedAccount> {
   const built = buildFetchNetworkAccountFromArchiver({
@@ -8300,7 +8289,6 @@ export function shardeumGetTime(): number {
  * Ok to log things without a verbose check here as this is a startup function
  */
 ;(async (): Promise<void> => {
-  setTimeout(periodicMemoryCleanup, 60000)
 
   await setupArchiverDiscovery({
     customArchiverList: config.server.p2p?.existingArchivers,

--- a/test/unit/src/state/shardeumStateCache.test.ts
+++ b/test/unit/src/state/shardeumStateCache.test.ts
@@ -1,0 +1,12 @@
+import { LRUCache } from 'lru-cache'
+
+describe('shardeumStateTXMap TTL', () => {
+  test('entries expire after ttl', async () => {
+    const cache = new LRUCache<string, number>({ max: 10, ttl: 50 })
+    cache.set('tx1', 1)
+    expect(cache.get('tx1')).toBe(1)
+    await new Promise((resolve) => setTimeout(resolve, 60))
+    expect(cache.get('tx1')).toBeUndefined()
+    expect(cache.size).toBe(0)
+  })
+})


### PR DESCRIPTION
### **User description**
## Summary
- switch `shardeumStateTXMap` to an `LRUCache` in `src/index.ts` and debug setup
- configure a ttl based cache instead of manual cleanup
- drop the old `periodicMemoryCleanup` helper
- add a unit test showing items expire after the configured ttl

## Testing
- `npm test` *(fails: Cannot find global type 'Array' ...)*


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replace `shardeumStateTXMap` with LRU cache for automatic eviction

- Configure cache with max size and TTL for entries

- Remove manual periodic memory cleanup logic

- Add unit test to verify cache TTL expiration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Use LRUCache for transaction state with TTL in debug setup</code></dd></summary>
<hr>

src/debug/evmSetup/index.ts

<li>Switch <code>shardeumStateTXMap</code> from Map to LRUCache with TTL and max size<br> <li> Update initialization to use LRUCache


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/502/files#diff-84f9a561db0e94e3efa556b702b437c8c2772846900e79c651cef265ae0ebe31">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Refactor per-tx state to LRUCache and remove manual cleanup</code></dd></summary>
<hr>

src/index.ts

<li>Replace <code>shardeumStateTXMap</code> Map with LRUCache for per-tx state<br> <li> Initialize LRUCache with max size and TTL<br> <li> Remove obsolete <code>periodicMemoryCleanup</code> function and its invocation


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/502/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+7/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shardeumStateCache.test.ts</strong><dd><code>Add unit test for LRUCache TTL expiration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/state/shardeumStateCache.test.ts

<li>Add unit test to verify LRUCache TTL expiration behavior<br> <li> Ensure cache entries expire and are removed after TTL


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/502/files#diff-5cccd7c80bd65b25434eda1f9843d78fb7bef8d9d204f75c8315b6edbd29ebe1">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>