### PR TITLE
Avoid duplicate internal tx receipts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2821,7 +2821,15 @@ async function applyInternalTx(
     //need to run this to fix buffer types after serialization
     fixDeserializedWrappedEVMAccount(wrappedEVMAccount)
     if (ShardeumFlags.supportInternalTxReceipt) {
-      createInternalTxReceipt(shardus, applyResponse, internalTx, networkAccount, networkAccount, txTimestamp, txId)
+      await createInternalTxReceipt(
+        shardus,
+        applyResponse,
+        internalTx,
+        networkAccount,
+        networkAccount,
+        txTimestamp,
+        txId
+      )
     }
   }
 
@@ -2844,7 +2852,15 @@ async function applyInternalTx(
       network.timestamp = txTimestamp
     }
     if (ShardeumFlags.supportInternalTxReceipt) {
-      createInternalTxReceipt(shardus, applyResponse, internalTx, networkAccount, networkAccount, txTimestamp, txId)
+      await createInternalTxReceipt(
+        shardus,
+        applyResponse,
+        internalTx,
+        networkAccount,
+        networkAccount,
+        txTimestamp,
+        txId
+      )
     }
     /* prettier-ignore */ if (logFlags.important_as_error) console.log(`init_network NETWORK_ACCOUNT: ${Utils.safeStringify(network)}`)
     /* prettier-ignore */ if (logFlags.important_as_error) shardus.log('Applied init_network transaction', network)
@@ -2927,7 +2943,15 @@ async function applyInternalTx(
       afterStateHash: afterStateHash,
     }
     if (ShardeumFlags.supportInternalTxReceipt) {
-      createInternalTxReceipt(shardus, applyResponse, internalTx, internalTx.from, networkAccount, txTimestamp, txId)
+      await createInternalTxReceipt(
+        shardus,
+        applyResponse,
+        internalTx,
+        internalTx.from,
+        networkAccount,
+        txTimestamp,
+        txId
+      )
     }
     /* prettier-ignore */ if (logFlags.important_as_error) console.log('Applied change_config tx')
     /* prettier-ignore */ if (logFlags.important_as_error) shardus.log('Applied change_config tx')
@@ -2956,7 +2980,15 @@ async function applyInternalTx(
     /* prettier-ignore */ if (logFlags.important_as_error) console.log(`Applied CHANGE_CONFIG GLOBAL transaction: ${Utils.safeStringify(network)}`)
     /* prettier-ignore */ if (logFlags.important_as_error) shardus.log('Applied CHANGE_CONFIG GLOBAL transaction', Utils.safeStringify(network))
     if (ShardeumFlags.supportInternalTxReceipt) {
-      createInternalTxReceipt(shardus, applyResponse, internalTx, internalTx.from, networkAccount, txTimestamp, txId)
+      await createInternalTxReceipt(
+        shardus,
+        applyResponse,
+        internalTx,
+        internalTx.from,
+        networkAccount,
+        txTimestamp,
+        txId
+      )
     }
   }
   if (internalTx.internalTXType === InternalTXType.ChangeNetworkParam) {
@@ -3004,7 +3036,15 @@ async function applyInternalTx(
       afterStateHash: afterStateHash,
     }
     if (ShardeumFlags.supportInternalTxReceipt) {
-      createInternalTxReceipt(shardus, applyResponse, internalTx, internalTx.from, networkAccount, txTimestamp, txId)
+      await createInternalTxReceipt(
+        shardus,
+        applyResponse,
+        internalTx,
+        internalTx.from,
+        networkAccount,
+        txTimestamp,
+        txId
+      )
     }
     /* prettier-ignore */ if (logFlags.important_as_error) console.log('Applied change_network_param tx')
     /* prettier-ignore */ if (logFlags.important_as_error) shardus.log('Applied change_network_param tx')
@@ -3031,18 +3071,26 @@ async function applyInternalTx(
       network.listOfChanges.push(internalTx.change)
     }
     if (ShardeumFlags.supportInternalTxReceipt) {
-      createInternalTxReceipt(shardus, applyResponse, internalTx, internalTx.from, networkAccount, txTimestamp, txId)
+      await createInternalTxReceipt(
+        shardus,
+        applyResponse,
+        internalTx,
+        internalTx.from,
+        networkAccount,
+        txTimestamp,
+        txId
+      )
     }
     /* prettier-ignore */ if (logFlags.important_as_error) console.log(`Applied CHANGE_NETWORK_PARAM GLOBAL transaction: ${Utils.safeStringify(network)}`)
     /* prettier-ignore */ if (logFlags.important_as_error) shardus.log('Applied CHANGE_NETWORK_PARAM GLOBAL transaction', Utils.safeStringify(network))
   }
   if (isSetCertTimeTx(internalTx)) {
     const setCertTimeTx = internalTx as SetCertTime
-    applySetCertTimeTx(shardus, setCertTimeTx, wrappedStates, txId, txTimestamp, applyResponse)
+    await applySetCertTimeTx(shardus, setCertTimeTx, wrappedStates, txId, txTimestamp, applyResponse)
   }
   if (internalTx.internalTXType === InternalTXType.InitRewardTimes) {
     const rewardTimesTx = internalTx as InitRewardTimes
-    InitRewardTimesTx.apply(shardus, rewardTimesTx, txId, txTimestamp, wrappedStates, applyResponse)
+    await InitRewardTimesTx.apply(shardus, rewardTimesTx, txId, txTimestamp, wrappedStates, applyResponse)
   }
   if (internalTx.internalTXType === InternalTXType.ClaimReward) {
     const claimRewardTx = internalTx as ClaimRewardTX
@@ -3084,7 +3132,7 @@ async function applyInternalTx(
   return applyResponse
 }
 
-export const createInternalTxReceipt = (
+export const createInternalTxReceipt = async (
   shardus,
   applyResponse: ShardusTypes.ApplyResponse,
   internalTx: InternalTx,
@@ -3096,9 +3144,18 @@ export const createInternalTxReceipt = (
   rewardAmount?: bigint,
   penaltyAmount?: bigint,
   secureAccountName?: string
-): void => {
+): Promise<void> => {
   const blockForReceipt = getOrCreateBlockFromTimestamp(txTimestamp)
   const blockNumberForTx = blockForReceipt.header.number.toString()
+
+  const receiptAccountType =
+    ShardeumFlags.addInternalTxReceiptAccount ? AccountType.InternalTxReceipt : AccountType.Receipt
+  const receiptAddress = toShardusAddress(txId, receiptAccountType)
+  const existingReceipt = await shardus.getLocalOrRemoteAccount(receiptAddress)
+  if (existingReceipt) {
+    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log(`Duplicate receipt for txId ${txId} already exists. Skipping creation.`)
+    return
+  }
   const readableReceipt: ReadableReceipt = {
     status: 1,
     transactionHash: '0x' + txId,

--- a/src/shardeum/secureAccounts.ts
+++ b/src/shardeum/secureAccounts.ts
@@ -396,7 +396,7 @@ export async function apply(
   )
 
   if (ShardeumFlags.supportInternalTxReceipt) {
-    createInternalTxReceipt(
+    await createInternalTxReceipt(
       shardus,
       applyResponse,
       tx,

--- a/src/tx/claimReward.ts
+++ b/src/tx/claimReward.ts
@@ -350,7 +350,7 @@ export async function applyClaimRewardTx(
   }
 
   if (ShardeumFlags.supportInternalTxReceipt) {
-    createInternalTxReceipt(
+    await createInternalTxReceipt(
       shardus,
       applyResponse,
       tx,

--- a/src/tx/initRewardTimes.ts
+++ b/src/tx/initRewardTimes.ts
@@ -171,14 +171,14 @@ export function validateInitRewardState(
   return { result: 'pass', reason: 'valid' }
 }
 
-export function apply(
+export async function apply(
   shardus,
   tx: InitRewardTimes,
   txId: string,
   txTimestamp: number,
   wrappedStates: WrappedStates,
   applyResponse: ShardusTypes.ApplyResponse
-): void {
+): Promise<void> {
   let nodeAccount: NodeAccount2
   const acct = wrappedStates[tx.nominee].data
   if (isNodeAccount2(acct)) {
@@ -213,7 +213,7 @@ export function apply(
     shardus.applyResponseAddChangedAccount(applyResponse, tx.nominee, wrappedChangedNodeAccount, txId, txTimestamp)
   }
   if (ShardeumFlags.supportInternalTxReceipt) {
-    createInternalTxReceipt(shardus, applyResponse, tx, tx.nominee, nodeAccount.nominator, txTimestamp, txId)
+    await createInternalTxReceipt(shardus, applyResponse, tx, tx.nominee, nodeAccount.nominator, txTimestamp, txId)
   }
   /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `Applied InitRewardTimesTX`)
   console.log('Applied InitRewardTimesTX for', tx.nominee)

--- a/src/tx/penalty/transaction.ts
+++ b/src/tx/penalty/transaction.ts
@@ -324,7 +324,7 @@ export async function applyPenaltyTX(
   }
 
   if (ShardeumFlags.supportInternalTxReceipt) {
-    createInternalTxReceipt(
+    await createInternalTxReceipt(
       shardus,
       applyResponse,
       tx,

--- a/src/tx/setCertTime.ts
+++ b/src/tx/setCertTime.ts
@@ -197,14 +197,14 @@ export function validateSetCertTimeState(
   return { result: 'pass', reason: 'valid' }
 }
 
-export function applySetCertTimeTx(
+export async function applySetCertTimeTx(
   shardus,
   tx: SetCertTime,
   wrappedStates: WrappedStates,
   txId: string,
   txTimestamp: number,
   applyResponse: ShardusTypes.ApplyResponse
-): void {
+): Promise<void> {
   /* prettier-ignore */ if (logFlags.dapp_verbose) console.log(`applySetCertTimeTx txTimestamp:${txTimestamp}   tx.timestamp:${tx.timestamp}`, tx)
 
   //TODO this is failing with a warning like this:
@@ -312,6 +312,6 @@ export function applySetCertTimeTx(
   }
 
   if (ShardeumFlags.supportInternalTxReceipt) {
-    createInternalTxReceipt(shardus, applyResponse, tx, tx.nominee, tx.nominator, txTimestamp, txId, amountSpent)
+    await createInternalTxReceipt(shardus, applyResponse, tx, tx.nominee, tx.nominator, txTimestamp, txId, amountSpent)
   }
 }

--- a/test/unit/src/tx/setCertTime.test.ts
+++ b/test/unit/src/tx/setCertTime.test.ts
@@ -365,25 +365,25 @@ describe('setCertTime', () => {
 
         const mockApplyResponse = {} as ShardusTypes.ApplyResponse
 
-        it('should successfully apply transaction', () => {
-            applySetCertTimeTx(mockShardus, validTx, mockWrappedStates, 'txId', 1000, mockApplyResponse)
+        it('should successfully apply transaction', async () => {
+            await applySetCertTimeTx(mockShardus, validTx, mockWrappedStates, 'txId', 1000, mockApplyResponse)
             expect(mockShardus.applyResponseAddChangedAccount).toHaveBeenCalled()
         })
 
-        it('should fail when state validation fails', () => {
+        it('should fail when state validation fails', async () => {
             mockNetworkAccount.current.stakeRequiredUsd = BigInt(2000)
-            applySetCertTimeTx(mockShardus, validTx, mockWrappedStates, 'txId', 1000, mockApplyResponse)
+            await applySetCertTimeTx(mockShardus, validTx, mockWrappedStates, 'txId', 1000, mockApplyResponse)
             expect(mockShardus.applyResponseSetFailed).toHaveBeenCalled()
         })
 
-        it('should charge tx fee when cert is not expired', () => {
-            applySetCertTimeTx(mockShardus, validTx, mockWrappedStates, 'txId', 1000, mockApplyResponse)
+        it('should charge tx fee when cert is not expired', async () => {
+            await applySetCertTimeTx(mockShardus, validTx, mockWrappedStates, 'txId', 1000, mockApplyResponse)
             expect(mockOperatorEVMAccount.account.balance).toBeDefined()
         })
 
-        it('should not charge tx fee when cert is expired', () => {
+        it('should not charge tx fee when cert is expired', async () => {
             mockOperatorEVMAccount.operatorAccountInfo.certExp = 1000
-            applySetCertTimeTx(mockShardus, validTx, mockWrappedStates, 'txId', 2000, mockApplyResponse)
+            await applySetCertTimeTx(mockShardus, validTx, mockWrappedStates, 'txId', 2000, mockApplyResponse)
             expect(mockOperatorEVMAccount.account.balance).toBe(BigInt(4096))
         })
     })


### PR DESCRIPTION
### **User description**
## Summary
- prevent duplicate internal receipt creation
- await the new async receipt function at all call sites
- adjust applySetCertTimeTx and InitRewardTimesTx to async
- update related tests for async calls

## Testing
- `npm test` *(fails: Cannot find global type 'Array')*


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Prevent duplicate internal transaction receipt creation

- Refactor receipt creation to be asynchronous throughout codebase

- Update transaction application functions to async/await

- Adjust related tests for async function signatures


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>index.ts</strong><dd><code>Make internal tx receipt creation async and deduplicate</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/504/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+67/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>secureAccounts.ts</strong><dd><code>Await internal tx receipt creation in secure account logic</code></dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/504/files#diff-94eb8abaacb4690d8c0ab0842382c7f050eaff91032822a0a7f64315f19c16b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>claimReward.ts</strong><dd><code>Await internal tx receipt creation in claim reward logic</code>&nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/504/files#diff-bb04a49d4b22f7daaa3c18fa4224d54cd90dfc918aa4fd8d640cceee5259bc16">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>initRewardTimes.ts</strong><dd><code>Make InitRewardTimesTx.apply async and await receipt creation</code></dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/504/files#diff-dd98aa8ec8256eaec054173b1cacc1c9d73d68379879f6c947d7384fc9228466">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transaction.ts</strong><dd><code>Await internal tx receipt creation in penalty transaction logic</code></dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/504/files#diff-753dabbe04057df4c04b60c520f33d4cf5551ced657ecaf664c3ceec982201ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>setCertTime.ts</strong><dd><code>Make applySetCertTimeTx async and await receipt creation</code>&nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/504/files#diff-801f96452344614d27069c631ad031a8fb1eca5974d2971e1acbc71bdb318c9c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>setCertTime.test.ts</strong><dd><code>Update tests for async applySetCertTimeTx function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/504/files#diff-a360f11356e1dadca8c587fcbc96f2c69966265d4b75a1f6081448cfd51287e0">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>