### PR TITLE
Avoid duplicate receipt sends

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -520,6 +520,9 @@ let shardusAddressToEVMAccountInfo: Map<string, EVMAccountInfo>
 export let evmCommon
 
 let debugAppdata: Map<string, unknown>
+// Track which transaction receipts have already been sent to avoid duplicates
+const processedReceipts = new Set<string>()
+const processedReceiptsMaxSize = 1000
 
 //todo refactor some object init into here
 async function initEVMSingletons(): Promise<void> {
@@ -3220,15 +3223,23 @@ async function _transactionReceiptPass(
   }
 
   if (appReceiptData) {
-    const dataId = toShardusAddressWithKey(appReceiptData.data.readableReceipt.transactionHash, '', AccountType.Receipt)
-    await shardus.sendCorrespondingCachedAppData(
-      'receipt',
-      dataId,
-      appReceiptData,
-      shardus.stateManager.currentCycleShardData.cycleNumber,
-      appReceiptData.data.txFrom,
-      appReceiptData.data.txId
-    )
+    const txHash = appReceiptData.data.readableReceipt.transactionHash
+    if (!processedReceipts.has(txHash)) {
+      processedReceipts.add(txHash)
+      if (processedReceipts.size > processedReceiptsMaxSize) {
+        const oldest = processedReceipts.values().next().value
+        processedReceipts.delete(oldest)
+      }
+      const dataId = toShardusAddressWithKey(txHash, '', AccountType.Receipt)
+      await shardus.sendCorrespondingCachedAppData(
+        'receipt',
+        dataId,
+        appReceiptData,
+        shardus.stateManager.currentCycleShardData.cycleNumber,
+        appReceiptData.data.txFrom,
+        appReceiptData.data.txId
+      )
+    }
   }
 
   //If this apply response has a global message defined then call setGlobal()


### PR DESCRIPTION
### **User description**
## Summary
- track processed receipts locally using a Set
- skip sending cached appdata if receipt already handled
- cap processed receipt history and prune when exceeded

## Testing
- `npm test` *(fails: Cannot find global type 'Array')*


___

### **PR Type**
Enhancement


___

### **Description**
- Add local tracking to prevent duplicate receipt sends

- Implement size cap and pruning for processed receipts set

- Integrate duplicate check into transaction receipt pass logic

- Minor logging and code structure improvements


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add duplicate receipt tracking and pruning logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.ts

<li>Introduced a Set to track processed transaction receipts.<br> <li> Added logic to skip sending receipts already handled.<br> <li> Implemented a maximum size and pruning for the processed receipts set.<br> <li> Updated transaction receipt pass to use the new tracking mechanism.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/505/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+20/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>