### PR TITLE
Fix async return for tryGetRemoteAccountCBNoOp

### DIFF
--- a/src/setup/sync.ts
+++ b/src/setup/sync.ts
@@ -398,13 +398,13 @@ function contractStorageInvolvedNoOp(
   return true
 }
 
-function tryGetRemoteAccountCBNoOp(
+async function tryGetRemoteAccountCBNoOp(
   _transactionState: TransactionState,
   _type: AccountType,
   _address: string,
   _key: string
 ): Promise<WrappedEVMAccount> {
-  return undefined
+  return Promise.resolve(undefined)
 }
 /* eslint-enable @typescript-eslint/no-unused-vars */
 


### PR DESCRIPTION
### **User description**
## Summary
- mark `tryGetRemoteAccountCBNoOp` as async
- return a resolved promise

## Testing
- `npm test --silent`


___

### **PR Type**
Bug fix


___

### **Description**
- Marked `tryGetRemoteAccountCBNoOp` as an async function

- Updated return value to a resolved promise

- Ensures correct async behavior for remote account retrieval


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.ts</strong><dd><code>Make tryGetRemoteAccountCBNoOp async and return resolved promise</code></dd></summary>
<hr>

src/setup/sync.ts

<li>Changed <code>tryGetRemoteAccountCBNoOp</code> to be async<br> <li> Updated return to <code>Promise.resolve(undefined)</code>


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/506/files#diff-daf7cf865a06ff2844339325bcf61f276c1c6afe9a8638a87a79adb6034eab1f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>