### PR TITLE
Fix negative bigint handling

### DIFF
--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -83,26 +83,35 @@ export const _readableSHM = (bnum: bigint, autoDecimal = true): string => {
   const unit_SHM = ' shm'
   const unit_WEI = ' wei'
 
-  if (!autoDecimal) return bnum.toString() + unit_WEI
+  const isNegative = bnum < BigInt(0)
+  if (isNegative) {
+    bnum = -bnum
+  }
+
+  if (!autoDecimal) return (isNegative ? '-' : '') + bnum.toString() + unit_WEI
 
   const numString = bnum.toString()
   // 1 eth or 1 SHM === 10^18 wei
   // if wei value gets too big let's convert to SHM in a floating point precision.
   // 14 is where we set this threshold. hardcoded for now.
+  let result: string
+
   if (numString.length > 14) {
     const floating_index = numString.length - 18
 
     if (floating_index <= 0) {
       const mantissa = '0'.repeat(Math.abs(floating_index)) + numString
-      return '0.' + mantissa + unit_SHM
+      result = '0.' + mantissa + unit_SHM
+    } else {
+      const mantissa = numString.slice(floating_index, numString.length)
+      const base = numString.slice(0, floating_index)
+      result = base + '.' + mantissa + unit_SHM
     }
-
-    const mantissa = numString.slice(floating_index, numString.length)
-    const base = numString.slice(0, floating_index)
-    return base + '.' + mantissa + unit_SHM
+  } else {
+    result = bnum.toString() + unit_WEI
   }
 
-  return bnum.toString() + unit_WEI
+  return (isNegative ? '-' : '') + result
 }
 
 export function debug_map_replacer<T, K, V>(key, value: T | Map<K, V>): T | [K, V][] {

--- a/test/unit/src/utils/serialization.test.ts
+++ b/test/unit/src/utils/serialization.test.ts
@@ -187,11 +187,10 @@ describe('Serialization Utility Functions', () => {
       expect(() => _readableSHM(123 as any)).toThrow('valid bigint instance')
     })
 
-    // TODO: fix the code to handle negative bigint values
-    // it('should handle negative bigint values', () => {
-    //   const num = BigInt(-12345678901234567890123)
-    //   expect(_readableSHM(num)).toBe('-12345.678901234567890123 shm')
-    // })
+    it('should handle negative bigint values', () => {
+      const num = BigInt('-12345678901234567890123')
+      expect(_readableSHM(num)).toBe('-12345.678901234567890123 shm')
+    })
 
     it('should handle zero value', () => {
       expect(_readableSHM(BigInt(0))).toBe('0 wei')


### PR DESCRIPTION
### **User description**
## Summary
- properly handle negative values in `_readableSHM`
- enable negative bigint serialization test

## Testing
- `npm run format-fix`
- `npm run lint`
- `npm run compile`
- `npm test --silent`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix negative bigint handling in `_readableSHM` function

- Add test for negative bigint serialization

- Ensure negative values are formatted with correct sign

- Improve code clarity for readability and maintainability


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serialization.ts</strong><dd><code>Add negative bigint support and refactor _readableSHM</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/serialization.ts

<li>Add support for negative bigint values in <code>_readableSHM</code><br> <li> Prepend negative sign to formatted output when needed<br> <li> Refactor logic for clarity and maintainability<br> <li> Ensure correct formatting for both SHM and WEI units


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/508/files#diff-05cc40db5bd5da59578a0ccebcad5d035f11fec7c5e5b550d042135eb1f18cc5">+16/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serialization.test.ts</strong><dd><code>Add test for negative bigint handling in _readableSHM</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/utils/serialization.test.ts

<li>Enable and update test for negative bigint serialization<br> <li> Verify output matches expected negative SHM format


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/508/files#diff-d180a8e3ce91bfd8baca840dfd87cf80e975fb3123fed262985ef9c18c245192">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>