### PR TITLE
Fix wildcard pattern escaping in middleware

### DIFF
--- a/src/middleware/externalApiMiddleware.ts
+++ b/src/middleware/externalApiMiddleware.ts
@@ -26,8 +26,10 @@ export const getExternalApiMiddleware = (): Handler => {
 function checkIfRequestIsAllowed(requestPath, requestMethod, allowedEndpoints): boolean {
   const endpointMatch = allowedEndpoints.find((endpoint) => {
     const [allowedMethod, allowedPattern] = endpoint.split(' ')
+    // Escape regex metacharacters, then replace '*' wildcards with '.*'
+    const escapedPattern = allowedPattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     // eslint-disable-next-line security/detect-non-literal-regexp
-    const pathRegex = new RegExp(`^${allowedPattern.replace(/\*/g, '.*')}$`)
+    const pathRegex = new RegExp(`^${escapedPattern.replace(/\\\*/g, '.*')}$`)
 
     return requestMethod === allowedMethod && pathRegex.test(requestPath)
   })

--- a/test/unit/src/middleware/externalApiMiddleware.test.ts
+++ b/test/unit/src/middleware/externalApiMiddleware.test.ts
@@ -1,0 +1,67 @@
+import { getExternalApiMiddleware } from '../../../../src/middleware/externalApiMiddleware'
+import { ShardeumFlags } from '../../../../src/shardeum/shardeumFlags'
+import { Request, Response } from 'express'
+
+describe('externalApiMiddleware - pattern matching', () => {
+  const originalServiceMode = ShardeumFlags.startInServiceMode
+  const originalAllowed = [...ShardeumFlags.allowedEndpointsInServiceMode]
+
+  afterEach(() => {
+    ShardeumFlags.startInServiceMode = originalServiceMode
+    ShardeumFlags.allowedEndpointsInServiceMode = [...originalAllowed]
+    jest.clearAllMocks()
+  })
+
+  test('should treat regex metacharacters literally', () => {
+    ShardeumFlags.startInServiceMode = true
+    ShardeumFlags.allowedEndpointsInServiceMode = ['GET /files/file[123].json']
+    const middleware = getExternalApiMiddleware()
+
+    const res: Partial<Response> = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    }
+
+    const next = jest.fn()
+    const req = { path: '/files/file[123].json', method: 'GET' } as Request
+    middleware(req, res as Response, next)
+    expect(next).toHaveBeenCalled()
+    expect((res.status as jest.Mock).mock.calls.length).toBe(0)
+
+    const disallowedRes: Partial<Response> = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    }
+    const disallowedNext = jest.fn()
+    const disallowedReq = { path: '/files/file1.json', method: 'GET' } as Request
+    middleware(disallowedReq, disallowedRes as Response, disallowedNext)
+    expect(disallowedNext).not.toHaveBeenCalled()
+    expect(disallowedRes.status).toHaveBeenCalledWith(403)
+  })
+
+  test('should match wildcard patterns with special characters', () => {
+    ShardeumFlags.startInServiceMode = true
+    ShardeumFlags.allowedEndpointsInServiceMode = ['GET /path/test$1/*']
+    const middleware = getExternalApiMiddleware()
+
+    const res: Partial<Response> = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    }
+    const next = jest.fn()
+    const req = { path: '/path/test$1/foo', method: 'GET' } as Request
+    middleware(req, res as Response, next)
+    expect(next).toHaveBeenCalled()
+    expect((res.status as jest.Mock).mock.calls.length).toBe(0)
+
+    const res2: Partial<Response> = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    }
+    const next2 = jest.fn()
+    const req2 = { path: '/path/test$2/foo', method: 'GET' } as Request
+    middleware(req2, res2 as Response, next2)
+    expect(next2).not.toHaveBeenCalled()
+    expect(res2.status).toHaveBeenCalledWith(403)
+  })
+})


### PR DESCRIPTION
### **User description**
## Summary
- improve `checkIfRequestIsAllowed` by escaping regex metacharacters
- add unit tests for external API middleware covering patterns with special characters

## Testing
- `npm test`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix regex escaping for wildcard patterns in middleware.

- Ensure special characters are treated literally in endpoint patterns.

- Add unit tests for pattern matching with special characters and wildcards.

- Improve security and correctness of endpoint access checks.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>externalApiMiddleware.ts</strong><dd><code>Escape regex metacharacters in endpoint pattern matching</code>&nbsp; </dd></summary>
<hr>

src/middleware/externalApiMiddleware.ts

<li>Escape regex metacharacters in allowed endpoint patterns.<br> <li> Ensure wildcards are handled after escaping special characters.<br> <li> Improve correctness of request path matching logic.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/511/files#diff-8352e5da4e81caaa21f67fc22ca95a0db001244c0cd974273bcf3004ea9acd28">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>externalApiMiddleware.test.ts</strong><dd><code>Add unit tests for middleware pattern matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/middleware/externalApiMiddleware.test.ts

<li>Add unit tests for literal matching of regex metacharacters.<br> <li> Test wildcard pattern matching with special characters.<br> <li> Verify correct middleware behavior for allowed/disallowed requests.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/511/files#diff-54b7d346c69b4b9068081bac672f42de1fce9545522014198911c9e4709a98e4">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>