### PR TITLE
Add unstake timestamp validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -245,6 +245,9 @@ export let adminCert: AdminCert = null
 
 const uuidCounter = 1
 
+// Allow a small drift when comparing unstake transaction timestamps
+const UNSTAKE_TIMESTAMP_DRIFT = 5 * ONE_SECOND
+
 interface DependenciesVersions {
   [key: string]: {
     version: string
@@ -4498,13 +4501,32 @@ const shardusSetup = (): void => {
         // get unstake tx from appData.internalTx
         const unstakeCoinsTX: UnstakeCoinsTX = appData.internalTx
 
-        // todo: validate tx timestamp, compare timestamp against account's timestamp
+        // validate tx timestamp against account timestamps
 
         // set stake value, nominee, cert in OperatorAcc (if not set yet)
         const operatorShardusAddress = toShardusAddress(unstakeCoinsTX.nominator, AccountType.Account)
         const nomineeNodeAccount2Address = unstakeCoinsTX.nominee
         // eslint-disable-next-line security/detect-object-injection
         const operatorEVMAccount: WrappedEVMAccount = wrappedStates[operatorShardusAddress].data as WrappedEVMAccount
+
+        // eslint-disable-next-line security/detect-object-injection
+        const nodeAccount2: NodeAccount2 = wrappedStates[nomineeNodeAccount2Address].data as NodeAccount2
+
+        if (
+          txTimestamp < operatorEVMAccount.timestamp - UNSTAKE_TIMESTAMP_DRIFT ||
+          txTimestamp < nodeAccount2.timestamp - UNSTAKE_TIMESTAMP_DRIFT
+        ) {
+          nestedCountersInstance.countEvent(
+            'shardeum-unstaking',
+            'unstake tx timestamp older than account timestamp'
+          )
+          shardus.applyResponseSetFailed(
+            applyResponse,
+            'Transaction timestamp older than account timestamp'
+          )
+          return applyResponse
+        }
+
         operatorEVMAccount.timestamp = txTimestamp
 
         if (operatorEVMAccount.operatorAccountInfo == null) {
@@ -4525,9 +4547,6 @@ const shardusSetup = (): void => {
             `Unable to apply Unstake tx because stake cert has not yet expired. Expiry timestamp ${operatorEVMAccount.operatorAccountInfo.certExp}`
           )
         }
-
-        // eslint-disable-next-line security/detect-object-injection
-        const nodeAccount2: NodeAccount2 = wrappedStates[nomineeNodeAccount2Address].data as NodeAccount2
 
         const currentBalance = operatorEVMAccount.account.balance
         const stake = BigInt(operatorEVMAccount.operatorAccountInfo.stake)

--- a/src/setup/validateTxnFields.ts
+++ b/src/setup/validateTxnFields.ts
@@ -28,6 +28,7 @@ import {
   isStakingEVMTx,
   formatErrorMessage,
 } from '../utils'
+import { ONE_SECOND } from '../shardeum/shardeumConstants'
 import {
   crypto,
   getInjectedOrGeneratedTimestamp,
@@ -73,6 +74,9 @@ const txTypeToAJVMap = {
 }
 
 let finalMultisigPermissions = multisigPermissions
+
+// Allow a small drift when comparing unstake transaction timestamps
+const UNSTAKE_TIMESTAMP_DRIFT = 5 * ONE_SECOND
 
 /* eslint-disable security/detect-non-literal-fs-filename */
 /* eslint-disable security/detect-object-injection */
@@ -553,7 +557,15 @@ export const validateTxnFields =
             reason = `This sender account is not found!`
           } else if (appData.nomineeAccount) {
             const nodeAccount = appData.nomineeAccount as NodeAccount2
-            if (!nodeAccount.nominator) {
+            const nominatorAccount = appData.nominatorAccount as WrappedEVMAccount
+
+            if (
+              txnTimestamp < nominatorAccount.timestamp - UNSTAKE_TIMESTAMP_DRIFT ||
+              txnTimestamp < nodeAccount.timestamp - UNSTAKE_TIMESTAMP_DRIFT
+            ) {
+              success = false
+              reason = `Transaction timestamp older than account timestamp`
+            } else if (!nodeAccount.nominator) {
               success = false
               reason = `No one has staked to this account!`
             } else if (_base16BNParser(nodeAccount.stakeLock) === BigInt(0)) {

--- a/test/unit/src/setup/unstakeTimestamp.test.ts
+++ b/test/unit/src/setup/unstakeTimestamp.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import { validateTxnFields } from '../../../../src/setup'
+import { InternalTXType, UnstakeCoinsTX, WrappedEVMAccount, NodeAccount2, AccountType, WrappedStates } from '../../../../src/shardeum/shardeumTypes'
+import { toShardusAddress } from '../../../../src/shardeum/evmAddress'
+import { nestedCountersInstance } from '@shardeum-foundation/core'
+import * as crypto from '@shardeum-foundation/lib-crypto-utils'
+
+jest.mock('@shardeum-foundation/lib-crypto-utils')
+
+jest.mock('@shardeum-foundation/core', () => ({
+  nestedCountersInstance: { countEvent: jest.fn() },
+}))
+
+const mockShardus = {
+  isOnStandbyList: jest.fn().mockReturnValue(false),
+  isNodeActiveByPubKey: jest.fn().mockReturnValue(false),
+  isNodeSelectedByPubKey: jest.fn().mockReturnValue(false),
+  isNodeReadyByPubKey: jest.fn().mockReturnValue(false),
+  isNodeSyncingByPubKey: jest.fn().mockReturnValue(false),
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('validateTxnFields - outdated unstake tx', () => {
+  test('should reject unstake tx older than account timestamps', () => {
+    const nominee = '0x' + '1'.repeat(64)
+    const nominator = '0x' + '2'.repeat(40)
+
+    const operatorAccount: WrappedEVMAccount = {
+      ethAddress: nominator,
+      hash: '0x0',
+      timestamp: 20000,
+      accountType: AccountType.Account,
+      account: {
+        balance: BigInt(0),
+        nonce: BigInt(0),
+        storageRoot: '',
+        codeHash: '',
+        _validate: () => true,
+        raw: () => Buffer.from(''),
+        serialize: () => Buffer.from(''),
+        isContract: () => false,
+      },
+      operatorAccountInfo: {
+        stake: BigInt(1),
+        nominee,
+        certExp: 0,
+        lastStakeTimestamp: 0,
+        operatorStats: {
+          totalNodeReward: BigInt(0),
+          totalNodePenalty: BigInt(0),
+          totalNodeTime: 0,
+          history: [],
+          totalUnstakeReward: BigInt(0),
+          unstakeCount: 0,
+          isShardeumRun: false,
+          lastStakedNodeKey: '',
+        },
+      },
+    }
+
+    const nodeAccount: NodeAccount2 = {
+      id: nominee,
+      hash: '0x0',
+      timestamp: 21000,
+      nominator,
+      stakeLock: BigInt(1),
+      stakeTimestamp: 0,
+      reward: BigInt(0),
+      rewardStartTime: 0,
+      rewardEndTime: 0,
+      penalty: BigInt(0),
+      nodeAccountStats: {
+        totalReward: BigInt(0),
+        totalPenalty: BigInt(0),
+        history: [],
+        lastPenaltyTime: 0,
+        penaltyHistory: [],
+        isShardeumRun: false,
+      },
+      rewarded: false,
+      rewardRate: BigInt(0),
+      nominatorStake: BigInt(0),
+      nominatorStakeTimestamp: 0,
+      accountType: AccountType.NodeAccount2,
+    }
+
+    ;(crypto.verifyObj as jest.Mock).mockReturnValue(true)
+
+    const unstakeTx: UnstakeCoinsTX = {
+      isInternalTx: true,
+      internalTXType: InternalTXType.Unstake,
+      nominee,
+      nominator,
+      timestamp: 10000,
+      sign: { owner: nominator, sig: '0x' },
+      force: false,
+    }
+
+    const validate = validateTxnFields(mockShardus as any, new Map())
+    const result = validate({ tx: unstakeTx }, {
+      internalTx: unstakeTx,
+      internalTXType: InternalTXType.Unstake,
+      nomineeAccount: nodeAccount,
+      nominatorAccount: operatorAccount,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.reason).toBe('Transaction timestamp older than account timestamp')
+    expect(nestedCountersInstance.countEvent).toHaveBeenCalledWith(
+      'shardeum',
+      'tx validation successful'
+    )
+  })
+})


### PR DESCRIPTION
### **User description**
## Summary
- reject unstake transactions older than nominator or nominee timestamps
- validate unstake tx timestamp in `validateTxnFields`
- add tests for outdated unstake transaction

## Testing
- `npm test` *(fails: TS2318 Cannot find global type 'Array')*


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enforces timestamp validation for unstake transactions.

- Rejects unstake transactions older than nominator or nominee timestamps.

- Adds unit tests for outdated unstake transaction scenarios.

- Introduces a small drift allowance for timestamp comparison.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add timestamp validation for unstake transactions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.ts

<li>Implements timestamp validation for unstake transactions.<br> <li> Rejects unstake tx if timestamp is older than nominator or nominee <br>account.<br> <li> Adds a drift constant for timestamp comparison.<br> <li> Refactors unstake logic to include new validation.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/512/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+23/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>validateTxnFields.ts</strong><dd><code>Validate unstake transaction timestamps in field validation</code></dd></summary>
<hr>

src/setup/validateTxnFields.ts

<li>Adds timestamp validation logic to unstake transaction field <br>validation.<br> <li> Rejects unstake tx if timestamp is too old compared to involved <br>accounts.<br> <li> Introduces drift constant for timestamp checks.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/512/files#diff-5acfde24899c2eb56a9186e2ac26b63f7a14599ee8c15518321ebb2396f755a6">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unstakeTimestamp.test.ts</strong><dd><code>Add tests for outdated unstake transaction validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/setup/unstakeTimestamp.test.ts

<li>Adds unit tests for outdated unstake transaction rejection.<br> <li> Mocks dependencies and sets up test accounts and transactions.<br> <li> Verifies rejection reason and event counting.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/512/files#diff-cd80a0b33f223ea18b8064ab7a3254ff111f230a7eb51d943d3c96cc9f06e62c">+117/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>