### PR TITLE
Fix validateSetCertTimeState missing account

### DIFF
--- a/src/tx/setCertTime.ts
+++ b/src/tx/setCertTime.ts
@@ -116,20 +116,23 @@ export function validateSetCertTimeState(
 ): { result: string; reason: string } {
   let committedStake = BigInt(0)
 
-  let operatorEVMAccount: WrappedEVMAccount
-  const acct = wrappedStates[toShardusAddress(tx.nominator, AccountType.Account)].data
-  if (WrappedEVMAccountFunctions.isWrappedEVMAccount(acct)) {
-    operatorEVMAccount = acct
+  let operatorEVMAccount: WrappedEVMAccount | undefined
+  const operatorAddr = toShardusAddress(tx.nominator, AccountType.Account)
+  const operatorWrapper = wrappedStates[operatorAddr]
+  if (
+    operatorWrapper != null &&
+    WrappedEVMAccountFunctions.isWrappedEVMAccount(operatorWrapper.data)
+  ) {
+    operatorEVMAccount = operatorWrapper.data
+    fixDeserializedWrappedEVMAccount(operatorEVMAccount)
   }
-  fixDeserializedWrappedEVMAccount(operatorEVMAccount)
   /* prettier-ignore */ if (logFlags.dapp_verbose) console.log('validateSetCertTimeState', tx, operatorEVMAccount)
   if (operatorEVMAccount == undefined) {
     /* prettier-ignore */ if (logFlags.dapp_verbose) console.log(`setCertTime validate state: found no wrapped state for operator account ${tx.nominator}`)
-    if (ShardeumFlags.fixCertExpTiming)
-      return {
-        result: 'fail',
-        reason: `Found no wrapped state for operator account ${tx.nominator}`,
-      }
+    return {
+      result: 'fail',
+      reason: `Found no wrapped state for operator account ${tx.nominator}`,
+    }
   } else {
     const transactionNominee = tx.nominee
     const operatorNominee = operatorEVMAccount.operatorAccountInfo.nominee

--- a/test/unit/src/tx/setCertTime.test.ts
+++ b/test/unit/src/tx/setCertTime.test.ts
@@ -319,19 +319,14 @@ describe('setCertTime', () => {
             expect(result.reason).toBe('valid')
         })
 
-        // TODO: Potentially a bug. validateSetCertTimeState() is not able to handle the 
-        // edge case wrapped states does not have the operator account. Even if the passed wrapped
-        // states array is supposed to have all accounts, the validateSetCertTimeState function should be 
-        // able to handle the case where the operator account is not found. Currently it will just break
-
-        // it('should reject when operator account is not found', () => {
-        //     const states = { ...mockWrappedStates }
-        //     const operatorAddress = toShardusAddress(validTx.nominator, AccountType.Account)
-        //     delete states[operatorAddress]
-        //     const result = validateSetCertTimeState(validTx, states)
-        //     expect(result.result).toBe('fail')
-        //     expect(result.reason).toContain('Found no wrapped state for operator account')
-        // })
+        it('should reject when operator account is not found', () => {
+            const states = { ...mockWrappedStates }
+            const operatorAddress = toShardusAddress(validTx.nominator, AccountType.Account)
+            delete states[operatorAddress]
+            const result = validateSetCertTimeState(validTx, states)
+            expect(result.result).toBe('fail')
+            expect(result.reason).toContain('Found no wrapped state for operator account')
+        })
 
         it('should reject when nominee mismatch', () => {
             const tx = { ...validTx, nominee: '0x9999' }


### PR DESCRIPTION
### **User description**
## Summary
- handle missing operator account in validateSetCertTimeState
- add regression test for missing operator account

## Testing
- `npm test`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix missing operator account handling in `validateSetCertTimeState`

- Always fail validation if operator account is missing

- Re-enable and update regression test for missing operator account


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setCertTime.ts</strong><dd><code>Robust handling of missing operator account in validation</code></dd></summary>
<hr>

src/tx/setCertTime.ts

<li>Improved handling for missing operator account in <br><code>validateSetCertTimeState</code><br> <li> Always returns fail if operator account is not found, regardless of <br>flags<br> <li> Refactored logic for clarity and robustness


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/514/files#diff-801f96452344614d27069c631ad031a8fb1eca5974d2971e1acbc71bdb318c9c">+13/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setCertTime.test.ts</strong><dd><code>Re-enable and update test for missing operator account</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/tx/setCertTime.test.ts

<li>Re-enabled and updated test for missing operator account case<br> <li> Ensures validation fails when operator account is absent<br> <li> Removed outdated comments about the bug


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/514/files#diff-a360f11356e1dadca8c587fcbc96f2c69966265d4b75a1f6081448cfd51287e0">+8/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>