### PR TITLE
Fix CHAIN_ID parsing

### DIFF
--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -157,7 +157,10 @@ export const ShardeumFlags: ShardeumFlags = {
   UseDBForAccounts: true,
   AppliedTxsMaps: false,
   SaveEVMTries: false,
-  ChainID: process.env.CHAIN_ID ? parseInt(process.env.CHAIN_ID) : 8082,
+  ChainID: (() => {
+    const parsed = parseInt(process.env.CHAIN_ID ?? '', 10)
+    return isNaN(parsed) ? 8082 : parsed
+  })(),
   CheckpointRevertSupport: true,
   UseTXPreCrack: true,
   NewStorageIndex: true,

--- a/test/unit/src/shardeum/shardeumFlags.test.ts
+++ b/test/unit/src/shardeum/shardeumFlags.test.ts
@@ -296,12 +296,11 @@ describe('ShardeumFlags', () => {
       expect(ReloadedFlags.ChainID).toBe(8082)
     })
 
-    it('should handle invalid CHAIN_ID environment variable', () => {
+    it('should fallback to default when CHAIN_ID is invalid', () => {
       process.env.CHAIN_ID = 'not-a-number'
       jest.resetModules()
       const { ShardeumFlags: ReloadedFlags } = require('../../../../src/shardeum/shardeumFlags')
-      // Should use NaN or default, depending on implementation
-      expect(isNaN(ReloadedFlags.ChainID) || ReloadedFlags.ChainID === 8082).toBeTruthy()
+      expect(ReloadedFlags.ChainID).toBe(8082)
     })
   })
 


### PR DESCRIPTION
### **User description**
## Summary
- ensure CHAIN_ID parsing defaults to 8082 when invalid
- update unit test for invalid CHAIN_ID

## Testing
- `CI=true npm test --silent`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Ensure robust parsing of `CHAIN_ID` environment variable

- Default to 8082 if `CHAIN_ID` is invalid or missing

- Update unit test to verify fallback behavior


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shardeumFlags.ts</strong><dd><code>Improve ChainID parsing with fallback to default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/shardeum/shardeumFlags.ts

<li>Refactored <code>ChainID</code> assignment to robustly parse environment variable<br> <li> Default to 8082 if <code>CHAIN_ID</code> is missing or not a valid number


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/519/files#diff-53f709116ea9cfd369021621f905892d7c768eab77678888ac6f6e45a1ca3a01">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shardeumFlags.test.ts</strong><dd><code>Update tests for ChainID fallback logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/shardeum/shardeumFlags.test.ts

<li>Updated test to expect fallback to 8082 for invalid <code>CHAIN_ID</code><br> <li> Improved test description for clarity on fallback behavior


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/519/files#diff-5923ea940501da3a95aa3d918260e012e532c8bbc64df840159f8c00e41d8801">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>