### PR TITLE
Handle revert with no checkpoint

### DIFF
--- a/src/state/cache.ts
+++ b/src/state/cache.ts
@@ -166,9 +166,18 @@ export default class Cache {
 
   /**
    * Revert changes to cache last checkpoint (no effect on trie).
-   */
+  */
   revert(): void {
-    this._cache = this._checkpoints.pop()
+    if (this._checkpoints.length > 0) {
+      const checkpoint = this._checkpoints.pop()
+      if (checkpoint) {
+        this._cache = checkpoint
+      } else {
+        console.warn('[Cache] revert called but checkpoint was undefined')
+      }
+    } else {
+      console.warn('[Cache] revert called with no checkpoint')
+    }
   }
 
   /**

--- a/test/unit/src/state/cache.test.ts
+++ b/test/unit/src/state/cache.test.ts
@@ -287,6 +287,11 @@ describe('Cache', () => {
       // Verify original state
       expect(cache.get(address1).balance).toEqual(BigInt(100))
     })
+
+    test('should not throw when reverting without a checkpoint', () => {
+      expect(() => cache.revert()).not.toThrow()
+      expect(cache._cache).toBeDefined()
+    })
   })
   
   describe('commit method', () => {


### PR DESCRIPTION
### **User description**
## Summary
- ensure cache revert() checks for checkpoints
- warn if revert() is called without any stored checkpoint
- add regression test for revert() with no checkpoint

## Testing
- `npx jest test/unit/src/state/cache.test.ts`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add safeguard in `revert()` for missing checkpoints

- Log warning if `revert()` called with no checkpoint

- Add regression test for `revert()` without checkpoint

- Ensure cache integrity when no checkpoint exists


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.ts</strong><dd><code>Add safety and warnings to cache revert method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/state/cache.ts

<li>Add check for empty <code>_checkpoints</code> before popping in <code>revert()</code><br> <li> Log warning if <code>revert()</code> is called with no checkpoint or undefined <br>checkpoint<br> <li> Prevents errors when reverting without a checkpoint


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/521/files#diff-4d1f5bdc99cc28309dbd6f9d7b52e475a6d325bf3579d03a84e7798288dcd0cc">+11/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.test.ts</strong><dd><code>Add regression test for revert without checkpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/state/cache.test.ts

<li>Add test to ensure <code>revert()</code> does not throw with no checkpoint<br> <li> Validate cache remains defined after such revert


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/521/files#diff-48dba5b00a5c674b515ab2073b45ccf0e9ea67a3a316e692b74f8134dec32f2c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>