### PR TITLE
Fix empty cache size result

### DIFF
--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -140,6 +140,9 @@ class Storage {
     try {
       const query = `SELECT COUNT(*) FROM riAccountsCache`
       const result = await this._query(query, [])
+      if (result.length === 0) {
+        return 0
+      }
       return result[0]['COUNT(*)']
     } catch (e) {
       throw new Error(e)

--- a/test/unit/src/storage/storage.test.ts
+++ b/test/unit/src/storage/storage.test.ts
@@ -508,6 +508,12 @@ describe('Storage', () => {
       await expect(storage.getRIAccountsCacheSize()).rejects.toThrow('Database error')
     })
 
+    it('should return 0 when the cache is empty', async () => {
+      mockStorage._rawQuery.mockResolvedValue([])
+      const result = await storage.getRIAccountsCacheSize()
+      expect(result).toBe(0)
+    })
+
     it('should throw an error if storage is not initialized', async () => {
       // Simulate storage not being initialized
       storage.initialized = false


### PR DESCRIPTION
### **User description**
## Summary
- handle empty cache when counting RI Accounts entries
- add test for empty cache size

## Testing
- `npm test`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix `getRIAccountsCacheSize` to return 0 for empty cache

- Add unit test for empty cache scenario

- Improve error handling for cache size retrieval


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.ts</strong><dd><code>Handle empty result in RI Accounts cache size query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/storage/storage.ts

<li>Return 0 if RI Accounts cache query returns empty result<br> <li> Add explicit check for empty query result in <code>getRIAccountsCacheSize</code>


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/526/files#diff-0c35bbf7139461c1a7f14a041877ce83458e0f9a84892478ddeb8177ef2048b2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.test.ts</strong><dd><code>Add unit test for empty RI Accounts cache size</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/storage/storage.test.ts

<li>Add test to verify 0 is returned for empty cache<br> <li> Ensure error is thrown for failed database operation


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/526/files#diff-691fa1975e667cb6a2d2f3831f8c6c827ea4cb31e4d8110198e6c83efe9430f0">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>