### PR TITLE
Fix decimal parsing and negative formatting

### DIFF
--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -59,8 +59,16 @@ export const _base16BNParser = (value: bigint | HexString | { __BigInt__: string
   throw new Error(`_base16BNParser: Unacceptable parameter value ${value}  typeof ${typeof value}`)
 }
 
+/**
+ * Parse a decimal string or bigint into a bigint.
+ *
+ * Empty strings are considered invalid and will throw an error.
+ */
 export const _base10BNParser = (value: bigint | DecimalString): bigint => {
   if (typeof value == 'string' && value.slice(0, 2) == '0x') {
+    throw new Error('Parameter value does not seem to be a valid base 10 (decimal)')
+  }
+  if (typeof value === 'string' && value.trim() === '') {
     throw new Error('Parameter value does not seem to be a valid base 10 (decimal)')
   }
   if (typeof value === 'string' && isNaN(value as unknown as number)) {
@@ -83,9 +91,12 @@ export const _readableSHM = (bnum: bigint, autoDecimal = true): string => {
   const unit_SHM = ' shm'
   const unit_WEI = ' wei'
 
-  if (!autoDecimal) return bnum.toString() + unit_WEI
+  const isNegative = bnum < BigInt(0)
+  const absNum = isNegative ? -bnum : bnum
 
-  const numString = bnum.toString()
+  if (!autoDecimal) return (isNegative ? '-' : '') + absNum.toString() + unit_WEI
+
+  const numString = absNum.toString()
   // 1 eth or 1 SHM === 10^18 wei
   // if wei value gets too big let's convert to SHM in a floating point precision.
   // 14 is where we set this threshold. hardcoded for now.
@@ -94,15 +105,15 @@ export const _readableSHM = (bnum: bigint, autoDecimal = true): string => {
 
     if (floating_index <= 0) {
       const mantissa = '0'.repeat(Math.abs(floating_index)) + numString
-      return '0.' + mantissa + unit_SHM
+      return (isNegative ? '-' : '') + '0.' + mantissa + unit_SHM
     }
 
     const mantissa = numString.slice(floating_index, numString.length)
     const base = numString.slice(0, floating_index)
-    return base + '.' + mantissa + unit_SHM
+    return (isNegative ? '-' : '') + base + '.' + mantissa + unit_SHM
   }
 
-  return bnum.toString() + unit_WEI
+  return (isNegative ? '-' : '') + absNum.toString() + unit_WEI
 }
 
 export function debug_map_replacer<T, K, V>(key, value: T | Map<K, V>): T | [K, V][] {

--- a/test/unit/src/utils/serialization.test.ts
+++ b/test/unit/src/utils/serialization.test.ts
@@ -140,10 +140,9 @@ describe('Serialization Utility Functions', () => {
       expect(() => _base10BNParser(null as any)).toThrow('Unacceptable parameter value')
     })
 
-    // TODO: fix the code to handle empty string input
-    // it('should throw an error for empty string input', () => {
-    //   expect(() => _base10BNParser('')).toThrow()
-    // })
+    it('should throw an error for empty string input', () => {
+      expect(() => _base10BNParser('')).toThrow()
+    })
 
     it('should throw an error for non-numeric string input', () => {
       expect(() => _base10BNParser('abc')).toThrow('valid base 10')
@@ -187,11 +186,10 @@ describe('Serialization Utility Functions', () => {
       expect(() => _readableSHM(123 as any)).toThrow('valid bigint instance')
     })
 
-    // TODO: fix the code to handle negative bigint values
-    // it('should handle negative bigint values', () => {
-    //   const num = BigInt(-12345678901234567890123)
-    //   expect(_readableSHM(num)).toBe('-12345.678901234567890123 shm')
-    // })
+    it('should handle negative bigint values', () => {
+      const num = BigInt('-12345678901234567890123')
+      expect(_readableSHM(num)).toBe('-12345.678901234567890123 shm')
+    })
 
     it('should handle zero value', () => {
       expect(_readableSHM(BigInt(0))).toBe('0 wei')


### PR DESCRIPTION
### **User description**
## Summary
- reject empty strings in `_base10BNParser`
- handle negative values in `_readableSHM`
- enable tests for empty strings and negative bigints

## Testing
- `npm test`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Reject empty strings in `_base10BNParser` with explicit error

- Correctly format negative values in `_readableSHM`

- Enable and add tests for empty string and negative bigint handling

- Improve error handling for invalid decimal parsing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serialization.ts</strong><dd><code>Improve decimal parsing and negative bigint formatting</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/serialization.ts

<li>Add check to reject empty string inputs in <code>_base10BNParser</code><br> <li> Enhance <code>_readableSHM</code> to handle and format negative bigints<br> <li> Improve error messages for invalid decimal parsing<br> <li> Refactor code for clarity and correctness in formatting


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/528/files#diff-05cc40db5bd5da59578a0ccebcad5d035f11fec7c5e5b550d042135eb1f18cc5">+16/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serialization.test.ts</strong><dd><code>Add and enable tests for edge case handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/utils/serialization.test.ts

<li>Enable test for empty string input in <code>_base10BNParser</code><br> <li> Enable and update test for negative bigint values in <code>_readableSHM</code><br> <li> Ensure tests cover new error handling and formatting logic


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/528/files#diff-d180a8e3ce91bfd8baca840dfd87cf80e975fb3123fed262985ef9c18c245192">+7/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>