### PR TITLE
Ensure deterministic timestamps in internal tx injections

### DIFF
--- a/src/tx/setCertTime.ts
+++ b/src/tx/setCertTime.ts
@@ -17,7 +17,7 @@ import {
 import * as WrappedEVMAccountFunctions from '../shardeum/wrappedEVMAccountFunctions'
 import { fixDeserializedWrappedEVMAccount } from '../shardeum/wrappedEVMAccountFunctions'
 import * as AccountsStorage from '../storage/accountStorage'
-import { getRandom, scaleByStabilityFactor, _base16BNParser, _readableSHM } from '../utils'
+import { getRandom, scaleByStabilityFactor, _base16BNParser, _readableSHM, sleep } from '../utils'
 
 import { createInternalTxReceipt, logFlags, shardeumGetTime } from '..'
 import { bigIntToHex, isValidAddress } from '@ethereumjs/util'
@@ -76,6 +76,19 @@ export async function injectSetCertTimeTx(
     nominator,
     duration: getCertCycleDuration(), //temp setting to 20 to make debugging easier
     timestamp: shardeumGetTime(),
+  }
+
+  if (ShardeumFlags.txHashingFix) {
+    const latestCycle = shardus.getLatestCycles(1)[0]
+    if (latestCycle) {
+      let futureTimestamp = (latestCycle.start + latestCycle.duration) * ONE_SECOND
+      while (futureTimestamp < shardeumGetTime()) {
+        futureTimestamp += 30 * ONE_SECOND
+      }
+      const waitTime = futureTimestamp - shardeumGetTime()
+      tx.timestamp = futureTimestamp
+      await sleep(waitTime)
+    }
   }
   tx = shardus.signAsNode(tx)
   const result = await InjectTxToConsensor([randomConsensusNode], tx)

--- a/test/unit/src/tx/deterministicTxId.test.ts
+++ b/test/unit/src/tx/deterministicTxId.test.ts
@@ -1,0 +1,121 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals'
+import { ShardeumFlags } from '../../../../src/shardeum/shardeumFlags'
+import { generateTxId } from '../../../../src/utils'
+import { sleep } from '../../../../src/utils'
+import { shardeumGetTime } from '../../../../src'
+import * as claimReward from '../../../../src/tx/claimReward'
+import * as initRewardTimes from '../../../../src/tx/initRewardTimes'
+import { injectSetCertTimeTx } from '../../../../src/tx/setCertTime'
+import { getNodeAccountWithRetry, InjectTxToConsensor } from '../../../../src/handlers/queryCertificate'
+
+jest.mock('../../../../src/utils', () => {
+  const actual = jest.requireActual('../../../../src/utils') as any
+  return { ...actual, sleep: jest.fn() }
+})
+jest.mock('../../../../src/handlers/queryCertificate')
+
+jest.mock('../../../../src', () => ({
+  shardeumGetTime: jest.fn(),
+  createInternalTxReceipt: jest.fn(),
+  logFlags: { dapp_verbose: false }
+}))
+
+describe('deterministic txId generation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(sleep as any).mockResolvedValue(undefined)
+  })
+
+  test('claimReward inject generates same txId across nodes', async () => {
+    const originalFlag = ShardeumFlags.txHashingFix
+    ShardeumFlags.txHashingFix = true
+    const mockNodeAccount = { rewardStartTime: 0, rewardEndTime: 0, nominator: '0xaaa' }
+    const mockEvent = {
+      publicKey: 'pubkey',
+      nodeId: 'node',
+      time: 50,
+      cycleNumber: 1,
+      additionalData: { txData: { endTime: 60, publicKey: 'pubkey' } }
+    }
+    const createShardus = () => ({
+      getLocalOrRemoteAccount: jest.fn(() => Promise.resolve({ data: mockNodeAccount } as any)),
+      signAsNode: jest.fn().mockImplementation((tx: any) => ({ ...tx, sign: { owner: 'a', sig: 'b' } })),
+      put: jest.fn()
+    })
+
+    const shardus1 = createShardus()
+    ;(shardeumGetTime as any).mockReturnValueOnce(1000)
+    await claimReward.injectClaimRewardTx(shardus1 as any, mockEvent as any)
+    const tx1 = shardus1.put.mock.calls[0][0]
+    const txId1 = generateTxId(tx1)
+
+    const shardus2 = createShardus()
+    ;(shardeumGetTime as any).mockReturnValueOnce(2000)
+    await claimReward.injectClaimRewardTx(shardus2 as any, mockEvent as any)
+    const tx2 = shardus2.put.mock.calls[0][0]
+    const txId2 = generateTxId(tx2)
+
+    expect(txId1).toBe(txId2)
+    ShardeumFlags.txHashingFix = originalFlag
+  })
+
+  test('initRewardTimes inject generates same txId across nodes', async () => {
+    const originalFlag = ShardeumFlags.txHashingFix
+    ShardeumFlags.txHashingFix = true
+    const mockNodeAccount = { rewardStartTime: 0, nominator: '0xaaa' }
+    const mockEvent = {
+      publicKey: 'pubkey',
+      nodeId: 'node',
+      time: 70,
+      additionalData: { txData: { startTime: 70, publicKey: 'pubkey' } }
+    }
+    const createShardus = () => ({
+      getLocalOrRemoteAccount: jest.fn(() => Promise.resolve({ data: mockNodeAccount } as any)),
+      signAsNode: jest.fn().mockImplementation((tx: any) => ({ ...tx, sign: { owner: 'a', sig: 'b' } })),
+      put: jest.fn()
+    })
+
+    const shardus1 = createShardus()
+    ;(shardeumGetTime as any).mockReturnValueOnce(1000)
+    await initRewardTimes.injectInitRewardTimesTx(shardus1 as any, mockEvent as any)
+    const tx1 = shardus1.put.mock.calls[0][0]
+    const txId1 = generateTxId(tx1)
+
+    const shardus2 = createShardus()
+    ;(shardeumGetTime as any).mockReturnValueOnce(2000)
+    await initRewardTimes.injectInitRewardTimesTx(shardus2 as any, mockEvent as any)
+    const tx2 = shardus2.put.mock.calls[0][0]
+    const txId2 = generateTxId(tx2)
+
+    expect(txId1).toBe(txId2)
+    ShardeumFlags.txHashingFix = originalFlag
+  })
+
+  test('setCertTime inject generates same txId across nodes', async () => {
+    const originalFlag = ShardeumFlags.txHashingFix
+    ShardeumFlags.txHashingFix = true
+    const mockActiveNodes = [{ id: 'node1', ip: '127.0.0.1', port: 3000, publicKey: 'pubkey' }]
+    const createShardus = () => ({
+      signAsNode: jest.fn().mockImplementation((tx: any) => ({ ...tx, sign: { owner: 'a', sig: 'b' } })),
+      getLatestCycles: jest.fn().mockReturnValue([{ start: 0, duration: 30 }]),
+      serviceQueue: { containsTxData: jest.fn().mockReturnValue(true) }
+    })
+    ;(getNodeAccountWithRetry as any).mockResolvedValue({ success: true, nodeAccount: { nominator: '0xaaa' } })
+    ;(InjectTxToConsensor as any).mockResolvedValue({ success: true })
+
+    const shardus1 = createShardus()
+    ;(shardeumGetTime as any).mockReturnValueOnce(1000)
+    await injectSetCertTimeTx(shardus1 as any, 'pubkey', mockActiveNodes)
+    const tx1 = (InjectTxToConsensor as unknown as jest.Mock).mock.calls[0][1]
+    const txId1 = generateTxId(tx1)
+
+    const shardus2 = createShardus()
+    ;(shardeumGetTime as any).mockReturnValueOnce(2000)
+    await injectSetCertTimeTx(shardus2 as any, 'pubkey', mockActiveNodes)
+    const tx2 = (InjectTxToConsensor as unknown as jest.Mock).mock.calls[1][1]
+    const txId2 = generateTxId(tx2)
+
+    expect(txId1).toBe(txId2)
+    ShardeumFlags.txHashingFix = originalFlag
+  })
+})

--- a/test/unit/src/tx/setCertTime.test.ts
+++ b/test/unit/src/tx/setCertTime.test.ts
@@ -66,6 +66,7 @@ describe('setCertTime', () => {
             signAsNode: jest.fn(),
             applyResponseSetFailed: jest.fn(),
             applyResponseAddChangedAccount: jest.fn(),
+            getLatestCycles: jest.fn().mockReturnValue([{ start: 0, duration: 30 }]),
         } as any
 
         // Setup mock network account


### PR DESCRIPTION
### **User description**
## Summary
- apply txHashingFix deterministic timestamp logic to `injectSetCertTimeTx`
- add unit tests verifying identical txIds when transactions are injected on different nodes
- update existing tests to mock cycle data

## Testing
- `npx jest test/unit/src/tx/deterministicTxId.test.ts`
- `npx jest test/unit/src/tx/setCertTime.test.ts` *(fails with OOM in this environment)*
- `npm test` *(fails with OOM in this environment)*


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enforce deterministic timestamps in `injectSetCertTimeTx`

- Add unit tests verifying deterministic txId generation

- Mock cycle data in setCertTime-related tests


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setCertTime.ts</strong><dd><code>Enforce deterministic timestamps in setCertTime injection</code></dd></summary>
<hr>

src/tx/setCertTime.ts

<li>Enforces deterministic timestamp logic in <code>injectSetCertTimeTx</code> when <br><code>txHashingFix</code> flag is enabled<br> <li> Uses latest cycle data to set future timestamp and waits accordingly<br> <li> Imports <code>sleep</code> utility for timing control


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/532/files#diff-801f96452344614d27069c631ad031a8fb1eca5974d2971e1acbc71bdb318c9c">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deterministicTxId.test.ts</strong><dd><code>Add tests for deterministic txId generation across nodes</code>&nbsp; </dd></summary>
<hr>

test/unit/src/tx/deterministicTxId.test.ts

<li>Adds comprehensive unit tests for deterministic txId generation across <br>nodes<br> <li> Mocks time, sleep, and external dependencies for isolation<br> <li> Tests <code>claimReward</code>, <code>initRewardTimes</code>, and <code>setCertTime</code> tx injections for <br>txId consistency


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/532/files#diff-5055af515b5bbe6486ebb31f1fb56e997e27bc2336a3bbee6e548efeed918a12">+121/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>setCertTime.test.ts</strong><dd><code>Mock cycle data for deterministic setCertTime tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/tx/setCertTime.test.ts

<li>Mocks <code>getLatestCycles</code> in Shardus for deterministic cycle data in tests<br> <li> Prepares for deterministic timestamp logic in setCertTime tests


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/532/files#diff-a360f11356e1dadca8c587fcbc96f2c69966265d4b75a1f6081448cfd51287e0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>