### PR TITLE
Fix SetCertTime injection timestamp

### DIFF
--- a/src/tx/setCertTime.ts
+++ b/src/tx/setCertTime.ts
@@ -17,7 +17,7 @@ import {
 import * as WrappedEVMAccountFunctions from '../shardeum/wrappedEVMAccountFunctions'
 import { fixDeserializedWrappedEVMAccount } from '../shardeum/wrappedEVMAccountFunctions'
 import * as AccountsStorage from '../storage/accountStorage'
-import { getRandom, scaleByStabilityFactor, _base16BNParser, _readableSHM } from '../utils'
+import { getRandom, scaleByStabilityFactor, _base16BNParser, _readableSHM, sleep } from '../utils'
 
 import { createInternalTxReceipt, logFlags, shardeumGetTime } from '..'
 import { bigIntToHex, isValidAddress } from '@ethereumjs/util'
@@ -76,6 +76,19 @@ export async function injectSetCertTimeTx(
     nominator,
     duration: getCertCycleDuration(), //temp setting to 20 to make debugging easier
     timestamp: shardeumGetTime(),
+  }
+
+  if (ShardeumFlags.txHashingFix) {
+    const [cycle] = shardus.getLatestCycles(1)
+    if (cycle) {
+      let futureTimestamp = (cycle.start + cycle.duration) * 1000
+      while (futureTimestamp < shardeumGetTime()) {
+        futureTimestamp += 30 * 1000
+      }
+      const waitTime = futureTimestamp - shardeumGetTime()
+      tx.timestamp = futureTimestamp
+      await sleep(waitTime)
+    }
   }
   tx = shardus.signAsNode(tx)
   const result = await InjectTxToConsensor([randomConsensusNode], tx)

--- a/test/unit/src/tx/setCertTime.test.ts
+++ b/test/unit/src/tx/setCertTime.test.ts
@@ -9,6 +9,7 @@ import { getNodeAccountWithRetry, InjectTxToConsensor } from '../../../../src/ha
 import { verify } from '../../../../src/setup/helpers'
 import { isInternalTx } from '../../../../src/setup/helpers'
 import { shardeumGetTime } from '../../../../src/index'
+import { generateTxId, sleep } from '../../../../src/utils'
 import * as WrappedEVMAccountFunctions from '../../../../src/shardeum/wrappedEVMAccountFunctions'
 
 // Mock dependencies
@@ -31,6 +32,10 @@ jest.mock('../../../../src/index', () => ({
         shardedCache: false,
         console: false
     }
+}))
+jest.mock('../../../../src/utils', () => ({
+    ...jest.requireActual('../../../../src/utils'),
+    sleep: jest.fn(),
 }))
 jest.mock('../../../../src/setup/helpers')
 jest.mock('../../../../src/shardeum/wrappedEVMAccountFunctions', () => ({
@@ -213,6 +218,7 @@ describe('setCertTime', () => {
 
                 // mock For shardeumGetTime
                 ; (shardeumGetTime as jest.Mock).mockReturnValue(Date.now())
+                ;(sleep as jest.Mock).mockResolvedValue(undefined)
         })
 
         it('should successfully inject SetCertTime transaction', async () => {
@@ -240,6 +246,37 @@ describe('setCertTime', () => {
             const result = await injectSetCertTimeTx(mockShardus, mockPublicKey, mockActiveNodes)
             expect(result.success).toBe(false)
             expect(result.reason).toContain('Nominator for this node account')
+        })
+
+        it('should produce identical tx hash across nodes', async () => {
+            const originalFlag = ShardeumFlags.txHashingFix
+            ShardeumFlags.txHashingFix = true
+            const cycle = { start: 0, duration: 10, counter: 1 }
+
+            const shardusA: jest.Mocked<Shardus> = {
+                signAsNode: jest.fn((tx) => tx),
+                getLatestCycles: jest.fn(() => [cycle]),
+            } as any
+            const shardusB: jest.Mocked<Shardus> = {
+                signAsNode: jest.fn((tx) => tx),
+                getLatestCycles: jest.fn(() => [cycle]),
+            } as any
+
+            ;(shardeumGetTime as jest.Mock).mockReturnValue(5000)
+            ;(sleep as jest.Mock).mockResolvedValue(undefined)
+
+            await injectSetCertTimeTx(shardusA, mockPublicKey, mockActiveNodes)
+            await injectSetCertTimeTx(shardusB, mockPublicKey, mockActiveNodes)
+
+            const txA = shardusA.signAsNode.mock.calls[0][0]
+            const txB = shardusB.signAsNode.mock.calls[0][0]
+
+            expect(txA.timestamp).toBe(txB.timestamp)
+            const hashA = generateTxId(txA)
+            const hashB = generateTxId(txB)
+            expect(hashA).toBe(hashB)
+
+            ShardeumFlags.txHashingFix = originalFlag
         })
     })
 


### PR DESCRIPTION
### **User description**
## Summary
- ensure SetCertTime injector uses deterministic timestamp when txHashingFix is set
- add unit test verifying that deterministic timestamp creates identical tx hashes across nodes

## Testing
- `npm test`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Ensure deterministic timestamp in SetCertTime when txHashingFix is enabled

- Add unit test verifying identical tx hashes across nodes

- Mock and test sleep behavior for deterministic timing

- Minor test setup improvements for mocking dependencies


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setCertTime.ts</strong><dd><code>Deterministic timestamp logic for SetCertTime injection</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/tx/setCertTime.ts

<li>Add logic to set deterministic timestamp when <br>ShardeumFlags.txHashingFix is true<br> <li> Calculate and wait for future timestamp aligned with cycle start and <br>duration<br> <li> Use sleep to synchronize transaction injection timing


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/534/files#diff-801f96452344614d27069c631ad031a8fb1eca5974d2971e1acbc71bdb318c9c">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setCertTime.test.ts</strong><dd><code>Add deterministic tx hash test and improve mocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/tx/setCertTime.test.ts

<li>Mock sleep utility for deterministic timing in tests<br> <li> Add test to verify identical tx hashes across nodes with txHashingFix<br> <li> Enhance test setup for mocking and dependency injection


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/534/files#diff-a360f11356e1dadca8c587fcbc96f2c69966265d4b75a1f6081448cfd51287e0">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>