### PR TITLE
Avoid reinjecting applied internal reward tx

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7854,15 +7854,33 @@ const shardusSetup = (): void => {
             console.log('nodereward tx data 1', data.additionalData.hash)
             if (shardus.fastIsPicked(1)) {
               console.log('nodereward tx data 2', data.additionalData.hash)
-              const result = await injectClaimRewardTx(shardus, data)
-              /* prettier-ignore */ if (logFlags.dapp_verbose) console.log('INJECTED_CLAIM_REWARD_TX',result)
+              const account = await shardus.getLocalOrRemoteAccount(data.publicKey)
+              if (
+                account?.data &&
+                isNodeAccount2(account.data) &&
+                (account.data as NodeAccount2).rewardEndTime >= data.additionalData.txData.endTime
+              ) {
+                /* prettier-ignore */ if (logFlags.dapp_verbose) console.log('try-network-transaction rewardEndTime already set')
+              } else {
+                const result = await injectClaimRewardTx(shardus, data)
+                /* prettier-ignore */ if (logFlags.dapp_verbose) console.log('INJECTED_CLAIM_REWARD_TX', result)
+              }
             }
           } else if (data?.additionalData.type === 'nodeInitReward') {
             /* prettier-ignore */ if (logFlags.dapp_verbose) console.log('shardeum-event', `running injectInitRewardTimesTx nodeInitReward`, safeStringify(data))
             if (shardus.fastIsPicked(1)) {
               console.log('nodeInitReward tx data 2', data.additionalData.hash)
-              const result = await InitRewardTimesTx.injectInitRewardTimesTx(shardus, data)
-              /* prettier-ignore */ if (logFlags.dapp_verbose) console.log('INJECTED_INIT_REWARD_TIMES_TX', result)
+              const account = await shardus.getLocalOrRemoteAccount(data.publicKey)
+              if (
+                account?.data &&
+                isNodeAccount2(account.data) &&
+                (account.data as NodeAccount2).rewardStartTime >= data.additionalData.txData.startTime
+              ) {
+                /* prettier-ignore */ if (logFlags.dapp_verbose) console.log('try-network-transaction rewardStartTime already set')
+              } else {
+                const result = await InitRewardTimesTx.injectInitRewardTimesTx(shardus, data)
+                /* prettier-ignore */ if (logFlags.dapp_verbose) console.log('INJECTED_INIT_REWARD_TIMES_TX', result)
+              }
             }
           }
         }


### PR DESCRIPTION
### **User description**
## Summary
- add rewardStartTime/rewardEndTime checks before reinjecting nodeReward or nodeInitReward transactions

## Testing
- `npm run compile`
- `npm run lint`
- `npm test`


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Prevent reinjection of internal reward transactions if already applied

- Add checks for `rewardStartTime` and `rewardEndTime` before reinjection

- Improve logging for skipped reinjections due to existing reward times

- Enhance transaction handler logic for node rewards


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add reward time checks to avoid duplicate reward transaction </code><br><code>reinjection</code></dd></summary>
<hr>

src/index.ts

<li>Added checks for <code>rewardEndTime</code> before reinjecting <code>nodeReward</code> <br>transactions<br> <li> Added checks for <code>rewardStartTime</code> before reinjecting <code>nodeInitReward</code> <br>transactions<br> <li> Improved logging to indicate when reinjection is skipped<br> <li> Enhanced transaction handler logic to avoid redundant reward <br>operations


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/535/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+22/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>