### PR TITLE
Remove deprecated SaveEVMTries flag

### DIFF
--- a/src/debug/state/shardeumState.ts
+++ b/src/debug/state/shardeumState.ts
@@ -96,7 +96,6 @@ export default class ShardeumState implements EVMStateManagerInterface {
 
   _transactionState: TransactionState
 
-  //TODO remvoe this once SaveEVMTries option goes away
   _trie: Trie
 
   // protected _storageTries: { [key: string]: Trie }
@@ -798,7 +797,6 @@ export default class ShardeumState implements EVMStateManagerInterface {
     this._touched.clear()
 
     // not sure yet if we need to implement this..
-    //throw new Error('cleanupTouchedAccounts not implemented yet when SaveEVMTries === false')
     return
 
     // TODO do we need to bring back some of this functionality?

--- a/src/debug/state/transactionState.ts
+++ b/src/debug/state/transactionState.ts
@@ -843,7 +843,6 @@ export default class TransactionState {
     this.touchedCAs.add(addressString)
   }
 
-  //should go away with SaveEVMTries = false
   async exectutePendingCAStateRoots(): Promise<void> {
     //for all touched CAs,
     // get CA storage trie.
@@ -858,7 +857,6 @@ export default class TransactionState {
     // It could be that this is the right answer for version 1 that is on a single shard anyhow!!
   }
 
-  //should go away with SaveEVMTries = false
   async generateTrieProofs(): Promise<void> {
     //alternative to exectutePendingCAStateRoots
     //in this code we would look at all READ CA keys and create a set of proofs on checkpointed trie.

--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -45,7 +45,6 @@ export interface ShardeumFlags {
   forwardGenesisAccounts: boolean // To send accounts from consensor rather than pulling from archiver
   UseDBForAccounts: boolean //Use Sql to store in memory accounts instead of simple accounts object map
   AppliedTxsMaps: boolean
-  SaveEVMTries: boolean //deprecated.  this was an old option to save evm tries
   ChainID: number // The EVM chain ID.  used by CHAINID opcode.
   CheckpointRevertSupport: boolean
   UseTXPreCrack: boolean
@@ -156,7 +155,6 @@ export const ShardeumFlags: ShardeumFlags = {
   forwardGenesisAccounts: true,
   UseDBForAccounts: true,
   AppliedTxsMaps: false,
-  SaveEVMTries: false,
   ChainID: process.env.CHAIN_ID ? parseInt(process.env.CHAIN_ID) : 8082,
   CheckpointRevertSupport: true,
   UseTXPreCrack: true,

--- a/src/state/shardeumState.ts
+++ b/src/state/shardeumState.ts
@@ -98,7 +98,6 @@ export default class ShardeumState implements EVMStateManagerInterface {
 
   _transactionState: TransactionState
 
-  //TODO remvoe this once SaveEVMTries option goes away
   _trie: Trie
 
   // protected _storageTries: { [key: string]: Trie }
@@ -802,7 +801,6 @@ export default class ShardeumState implements EVMStateManagerInterface {
     this._touched.clear()
 
     // not sure yet if we need to implement this..
-    //throw new Error('cleanupTouchedAccounts not implemented yet when SaveEVMTries === false')
     return
 
     // TODO do we need to bring back some of this functionality?

--- a/src/state/transactionState.ts
+++ b/src/state/transactionState.ts
@@ -872,7 +872,6 @@ export default class TransactionState {
     this.touchedCAs.add(addressString)
   }
 
-  //should go away with SaveEVMTries = false
   async exectutePendingCAStateRoots(): Promise<void> {
     //for all touched CAs,
     // get CA storage trie.
@@ -887,7 +886,6 @@ export default class TransactionState {
     // It could be that this is the right answer for version 1 that is on a single shard anyhow!!
   }
 
-  //should go away with SaveEVMTries = false
   async generateTrieProofs(): Promise<void> {
     //alternative to exectutePendingCAStateRoots
     //in this code we would look at all READ CA keys and create a set of proofs on checkpointed trie.

--- a/test/unit/src/shardeum/shardeumFlags.test.ts
+++ b/test/unit/src/shardeum/shardeumFlags.test.ts
@@ -272,7 +272,6 @@ describe('ShardeumFlags', () => {
         expect(ShardeumFlags.generateMemoryPatternData).toBe(true)
         expect(ShardeumFlags.labTest).toBe(false)
         expect(ShardeumFlags.AppliedTxsMaps).toBe(false)
-        expect(ShardeumFlags.SaveEVMTries).toBe(false)
         expect(ShardeumFlags.CheckpointRevertSupport).toBe(true)
         expect(ShardeumFlags.disableSmartContractEndpoints).toBe(true)
         expect(ShardeumFlags.accessListSizeLimit).toBe(5)


### PR DESCRIPTION
### **User description**
## Summary
- remove `SaveEVMTries` from `ShardeumFlags` interface and defaults
- drop comments referencing the flag in state code
- update tests for new flag set

## Testing
- `npm test`


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Remove deprecated `SaveEVMTries` flag from `ShardeumFlags` interface and defaults

- Clean up related comments referencing `SaveEVMTries` in state and transaction code

- Update unit tests to remove checks for `SaveEVMTries`

- Streamline code by eliminating obsolete flag dependencies


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shardeumFlags.ts</strong><dd><code>Remove SaveEVMTries from flags interface and defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/shardeum/shardeumFlags.ts

<li>Remove <code>SaveEVMTries</code> from <code>ShardeumFlags</code> interface<br> <li> Remove <code>SaveEVMTries</code> from default flag values


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/539/files#diff-53f709116ea9cfd369021621f905892d7c768eab77678888ac6f6e45a1ca3a01">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>shardeumState.ts</strong><dd><code>Remove SaveEVMTries comments from shardeumState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/debug/state/shardeumState.ts

<li>Remove comment referencing SaveEVMTries in trie property<br> <li> Remove obsolete commented error in cleanupTouchedAccounts


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/539/files#diff-0ce7e83e81a939fc3da48d142f4ecb38ba90ba1937fcd8adf91b095fd57fade0">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transactionState.ts</strong><dd><code>Remove SaveEVMTries comments from transactionState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/debug/state/transactionState.ts

- Remove comments referencing SaveEVMTries in method headers


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/539/files#diff-542f2516a96be5b35d52688961e48de9e6691aa237cd993b79615c623559703a">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>shardeumState.ts</strong><dd><code>Remove SaveEVMTries comments from shardeumState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/state/shardeumState.ts

<li>Remove comment referencing SaveEVMTries in trie property<br> <li> Remove obsolete commented error in cleanupTouchedAccounts


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/539/files#diff-e3cc08efb0458d97f3388e5129c7129af3c5b8d504f547811d2b95253c85b45d">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transactionState.ts</strong><dd><code>Remove SaveEVMTries comments from transactionState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/state/transactionState.ts

- Remove comments referencing SaveEVMTries in method headers


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/539/files#diff-3cd3fb5b521141d7f3cede2fcc72797c2920ee7e8a440029a266bb9dd8808674">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shardeumFlags.test.ts</strong><dd><code>Remove SaveEVMTries test from ShardeumFlags tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/shardeum/shardeumFlags.test.ts

- Remove test assertion for `ShardeumFlags.SaveEVMTries`


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/539/files#diff-5923ea940501da3a95aa3d918260e012e532c8bbc64df840159f8c00e41d8801">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>