### PR TITLE
Remove unused backoff flag

### DIFF
--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -72,7 +72,6 @@ export interface ShardeumFlags {
   allowForceUnstake: boolean
   ClaimRewardRetryCount: number
   shardeumTimeout: number
-  FailedTxLinearBackOffConstantInSecs: number
   fixExtraStakeLessThanMin: boolean
   unstakeCertCheckFix: boolean
   fixCertExpRenew: boolean
@@ -196,7 +195,6 @@ export const ShardeumFlags: ShardeumFlags = {
   minNodesEVMtx: 5,
   ClaimRewardRetryCount: 20,
   shardeumTimeout: 50000,
-  FailedTxLinearBackOffConstantInSecs: 30,
   logServicePointSenders: false,
   labTest: false,
   lowStakePercent: 0.2,

--- a/test/unit/src/shardeum/shardeumFlags.test.ts
+++ b/test/unit/src/shardeum/shardeumFlags.test.ts
@@ -226,7 +226,6 @@ describe('ShardeumFlags', () => {
         expect(ShardeumFlags.accesslistNonceFix).toBe(true)
         expect(ShardeumFlags.internalTxTimestampFix).toBe(true)
         expect(ShardeumFlags.expiredTransactionStateFix).toBe(false)
-        expect(ShardeumFlags.FailedTxLinearBackOffConstantInSecs).toBe(30)
       })
     })
 


### PR DESCRIPTION
### **User description**
## Summary
- drop FailedTxLinearBackOffConstantInSecs flag
- update tests

## Testing
- `npm test`


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Remove `FailedTxLinearBackOffConstantInSecs` flag from codebase

- Update tests to reflect flag removal

- Clean up interface and default flag values


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shardeumFlags.ts</strong><dd><code>Remove FailedTxLinearBackOffConstantInSecs from flags and defaults</code></dd></summary>
<hr>

src/shardeum/shardeumFlags.ts

<li>Removed <code>FailedTxLinearBackOffConstantInSecs</code> from <code>ShardeumFlags</code> <br>interface<br> <li> Deleted default value assignment for the removed flag<br> <li> Cleaned up related comments and structure


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/540/files#diff-53f709116ea9cfd369021621f905892d7c768eab77678888ac6f6e45a1ca3a01">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shardeumFlags.test.ts</strong><dd><code>Remove test for deleted FailedTxLinearBackOffConstantInSecs flag</code></dd></summary>
<hr>

test/unit/src/shardeum/shardeumFlags.test.ts

<li>Removed test assertion for <code>FailedTxLinearBackOffConstantInSecs</code><br> <li> Updated test to match new flag structure


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/540/files#diff-5923ea940501da3a95aa3d918260e012e532c8bbc64df840159f8c00e41d8801">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>