### PR TITLE
Remove ClaimRewardRetryCount flag

### DIFF
--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -70,7 +70,6 @@ export interface ShardeumFlags {
   minNodesEVMtx: number
   checkNodesEVMtx: boolean
   allowForceUnstake: boolean
-  ClaimRewardRetryCount: number
   shardeumTimeout: number
   FailedTxLinearBackOffConstantInSecs: number
   fixExtraStakeLessThanMin: boolean
@@ -194,7 +193,6 @@ export const ShardeumFlags: ShardeumFlags = {
   FullCertChecksEnabled: true,
   extraTxTime: 8, // This is to predict the cycleNumber from the tx timestamp + 8s
   minNodesEVMtx: 5,
-  ClaimRewardRetryCount: 20,
   shardeumTimeout: 50000,
   FailedTxLinearBackOffConstantInSecs: 30,
   logServicePointSenders: false,

--- a/test/unit/src/shardeum/shardeumFlags.test.ts
+++ b/test/unit/src/shardeum/shardeumFlags.test.ts
@@ -234,7 +234,6 @@ describe('ShardeumFlags', () => {
     describe('Certificate and Admin Features', () => {
       it('should have correct default values for certificate and admin features', () => {
         expect(ShardeumFlags.AdminCertEnabled).toBe(false)
-        expect(ShardeumFlags.ClaimRewardRetryCount).toBe(20)
         expect(ShardeumFlags.fixCertExpRenew).toBe(true)
         expect(ShardeumFlags.fixSetCertTimeTxApply).toBe(true)
         expect(ShardeumFlags.setCertTimeDurationOverride).toBe(true)


### PR DESCRIPTION
### **User description**
## Summary
- drop ClaimRewardRetryCount from ShardeumFlags
- update unit test expectations

## Testing
- `npm test --silent`


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Removed `ClaimRewardRetryCount` flag from `ShardeumFlags` interface and object.

- Updated unit tests to remove checks for `ClaimRewardRetryCount`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shardeumFlags.ts</strong><dd><code>Remove ClaimRewardRetryCount from ShardeumFlags definition</code></dd></summary>
<hr>

src/shardeum/shardeumFlags.ts

<li>Removed <code>ClaimRewardRetryCount</code> from <code>ShardeumFlags</code> interface.<br> <li> Deleted <code>ClaimRewardRetryCount</code> property from <code>ShardeumFlags</code> object.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/541/files#diff-53f709116ea9cfd369021621f905892d7c768eab77678888ac6f6e45a1ca3a01">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shardeumFlags.test.ts</strong><dd><code>Remove test for ClaimRewardRetryCount in ShardeumFlags</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/shardeum/shardeumFlags.test.ts

- Removed unit test assertion for `ClaimRewardRetryCount`.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/541/files#diff-5923ea940501da3a95aa3d918260e012e532c8bbc64df840159f8c00e41d8801">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>