### PR TITLE
Validate contract call payload using AJV

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1852,6 +1852,11 @@ const configShardusEndpoints = (): void => {
 
     try {
       const callObj = req.body
+      const errors = verifyPayload(AJVSchemaEnum.ContractCallReq, callObj)
+      if (errors) {
+        res.status(400).json({ error: 'Invalid call object', details: isDebugMode() ? errors : undefined })
+        return
+      }
       if (ShardeumFlags.VerboseLogs) console.log('callObj', callObj)
       const opt = {
         to: Address.fromString(callObj.to),

--- a/src/types/ajv/ContractCallSchema.ts
+++ b/src/types/ajv/ContractCallSchema.ts
@@ -1,0 +1,28 @@
+import { addSchema } from '../../utils/serialization/SchemaHelpers'
+import { AJVSchemaEnum } from '../enum/AJVSchemaEnum'
+
+const schemaContractCallReq = {
+  type: 'object',
+  properties: {
+    to: { type: 'string', pattern: '^0x[a-fA-F0-9]{40}$' },
+    from: { type: 'string', pattern: '^0x[a-fA-F0-9]{40}$' },
+    data: { type: 'string', pattern: '^0x[a-fA-F0-9]*$' },
+    gas: { anyOf: [ { type: 'number' }, { type: 'string', pattern: '^[0-9]+$' } ] },
+    gasPrice: { type: 'string', pattern: '^0x[a-fA-F0-9]+$' },
+  },
+  required: ['to', 'from', 'data'],
+  additionalProperties: false,
+}
+
+export function initContractCallReq(): void {
+  addSchemaDependencies()
+  addSchemas()
+}
+
+function addSchemaDependencies(): void {
+  // No dependencies
+}
+
+function addSchemas(): void {
+  addSchema(AJVSchemaEnum.ContractCallReq, schemaContractCallReq)
+}

--- a/src/types/ajv/Helpers.ts
+++ b/src/types/ajv/Helpers.ts
@@ -19,6 +19,7 @@ import { initClaimRewardTx } from './ClaimRewardTxSchema'
 import { initTransferFromSecureAccountTx } from './TransferFromSecureAccountTxSchema'
 import { initUnstakeTx } from './UnstakeTxSchema'
 import { initInitNetworkTx } from './InitNetworkTxSchema'
+import { initContractCallReq } from './ContractCallSchema'
 
 export function initAjvSchemas(): void {
   initSign()
@@ -39,6 +40,7 @@ export function initAjvSchemas(): void {
   initStakeTx()
   initUnstakeTx()
   initTransferFromSecureAccountTx()
+  initContractCallReq()
 }
 
 export function verifyPayload<T>(name: string, payload: T): string[] | null {

--- a/src/types/enum/AJVSchemaEnum.ts
+++ b/src/types/enum/AJVSchemaEnum.ts
@@ -24,4 +24,5 @@ export enum AJVSchemaEnum {
   NodeRewardTxData = 'NodeRewardTxData',
   NodeInitTxData = 'NodeInitTxData',
   InitRewardTimesTx = 'InitRewardTimesTx',
+  ContractCallReq = 'ContractCallReq',
 }

--- a/test/unit/src/types/ajv/Helpers.test.ts
+++ b/test/unit/src/types/ajv/Helpers.test.ts
@@ -22,10 +22,12 @@ import { initClaimRewardTx } from '../../../../../src/types/ajv/ClaimRewardTxSch
 import { initTransferFromSecureAccountTx } from '../../../../../src/types/ajv/TransferFromSecureAccountTxSchema'
 import { initUnstakeTx } from '../../../../../src/types/ajv/UnstakeTxSchema'
 import { initInitNetworkTx } from '../../../../../src/types/ajv/InitNetworkTxSchema'
+import { initContractCallReq } from '../../../../../src/types/ajv/ContractCallSchema'
 import Ajv from 'ajv'
 
 jest.mock('../../../../../src/utils/serialization/SchemaHelpers', () => ({
   getVerifyFunction: jest.fn(),
+  addSchema: jest.fn(),
 }))
 
 jest.mock('../../../../../src/types/ajv/InjectTxReq', () => ({
@@ -92,6 +94,10 @@ jest.mock('../../../../../src/types/ajv/TransferFromSecureAccountTxSchema', () =
   initTransferFromSecureAccountTx: jest.fn(),
 }))
 
+jest.mock('../../../../../src/types/ajv/ContractCallSchema', () => ({
+  initContractCallReq: jest.fn(),
+}))
+
 jest.mock('../../../../../src/types/ajv/UnstakeTxSchema', () => ({
   initUnstakeTx: jest.fn(),
 }))
@@ -120,6 +126,7 @@ describe('Ajv Helpers', () => {
       expect(initInitRewardTimesTx).toHaveBeenCalledTimes(1)
       expect(initClaimRewardTx).toHaveBeenCalledTimes(1)
       expect(initTransferFromSecureAccountTx).toHaveBeenCalledTimes(1)
+      expect(initContractCallReq).toHaveBeenCalledTimes(1)
       expect(initUnstakeTx).toHaveBeenCalledTimes(1)
       expect(initInitNetworkTx).toHaveBeenCalledTimes(1)
     })


### PR DESCRIPTION
### **User description**
## Summary
- validate contract call inputs via new AJV schema
- register new schema on startup
- ensure helpers tests expect new initializer
- reject invalid call objects with HTTP 400

## Testing
- `npm test`


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add AJV schema validation for contract call endpoint

- Register new `ContractCallReq` schema during startup

- Return HTTP 400 for invalid contract call payloads

- Update and extend unit tests for schema initialization


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add AJV validation to contract call endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.ts

<li>Validate contract call payload using AJV before processing<br> <li> Return HTTP 400 with error details for invalid payloads


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/543/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ContractCallSchema.ts</strong><dd><code>Add AJV schema definition for contract call requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types/ajv/ContractCallSchema.ts

<li>Define AJV schema for contract call request payload<br> <li> Register schema via <code>addSchema</code> function<br> <li> Provide initialization function for schema registration


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/543/files#diff-0f0c699e19c54cd3fd999e0a5a7e05e19d81298ded2b4c1175f6bbc1145a62b9">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Helpers.ts</strong><dd><code>Register contract call schema in AJV helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types/ajv/Helpers.ts

<li>Register contract call request schema in AJV initialization<br> <li> Import and invoke <code>initContractCallReq</code> during schema setup


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/543/files#diff-b148650cb180503e2fc752286f2f8090dda6b4f7f46f0f45a450edcf79401d2c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AJVSchemaEnum.ts</strong><dd><code>Add ContractCallReq to AJV schema enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types/enum/AJVSchemaEnum.ts

- Add `ContractCallReq` to AJV schema enum


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/543/files#diff-78c19c28d90163a71b2816ecd936ae7699e2a115e0f559fe49e1ccdd2f451aea">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Helpers.test.ts</strong><dd><code>Test contract call schema registration in AJV helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/types/ajv/Helpers.test.ts

<li>Mock and test initialization of contract call schema<br> <li> Assert <code>initContractCallReq</code> is called during AJV schema setup


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/543/files#diff-9bd706aa2b8cf14584996aec27fadd5305401866a59b87bece058aaa4b0f1736">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>