### PR TITLE
set flexibleRotationDelta to 0 for testnet

### DIFF
--- a/environments/testnet.config.json
+++ b/environments/testnet.config.json
@@ -5,7 +5,7 @@
       "minNodes": 20,
       "maxNodes": 1280,
       "syncingDesiredMinCount": 5,
-      "flexibleRotationDelta": 4,
+      "flexibleRotationDelta": 0,
       "formingNodesPerCycle": 20,
       "allowEndUserTxnInjections": true
     },


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Set `flexibleRotationDelta` to 0 in testnet configuration

- Updates testnet P2P server behavior for node rotation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>testnet.config.json</strong><dd><code>Update testnet P2P config: set `flexibleRotationDelta` to 0</code></dd></summary>
<hr>

environments/testnet.config.json

<li>Changed <code>flexibleRotationDelta</code> from 4 to 0 in P2P server config<br> <li> Alters node rotation flexibility for testnet environment


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/546/files#diff-3e342edcba5fb03899a724416af711e17ec5ae210041cac822eed0561dacbfbe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>