### PR TITLE
SHARD-2471: Update messaging around cert stake lock

### DIFF
--- a/src/tx/staking/verifyStake.ts
+++ b/src/tx/staking/verifyStake.ts
@@ -244,7 +244,7 @@ export function isStakeUnlocked(
       unlocked: false,
       reason: `Your node is currently registered in the network. Deregistration will be completed in ${remainingMinutes} minute${
         remainingMinutes === 1 ? '' : 's'
-      }. You'll be able to unstake once this completed.`,
+      }. You'll be able to unstake once deregistration is complete.`,
       remainingTime: nominatorAccount.operatorAccountInfo.certExp - currentTime,
     }
   }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Clarified messaging for stake unlock during deregistration.

- Improved user guidance on unstaking process.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verifyStake.ts</strong><dd><code>Clarified stake unlock message for deregistration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tx/staking/verifyStake.ts

<li>Updated the reason message for stake unlock status.<br> <li> Clarified that unstaking is possible once deregistration is complete.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/551/files#diff-535052d2715b8eef31b43450b02a05dc4598c36bc60d6a6998d2f7a9a68a2e26">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>