### PR TITLE
SHARD-2628: Remove unused flag globalCodeBytes and related code

### DIFF
--- a/scripts/dupeTxNonceCheck.ts
+++ b/scripts/dupeTxNonceCheck.ts
@@ -51,7 +51,6 @@ const colors = {
 
 // Internal TX Type mapping
 const InternalTXType = {
-  0: "SetGlobalCodeBytes",
   1: "InitNetwork",
   2: "NodeReward",
   3: "ChangeConfig",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2800,7 +2800,7 @@ const configShardusNetworkTransactions = (): void => {
  * @returns A promise that resolves to a ShardusTypes.ApplyResponse object.
  *
  * The function handles different types of internal transactions:
- * - `SetGlobalCodeBytes`: Updates the timestamp of the wrapped EVM account and optionally creates an internal transaction receipt.
+ * - (SetGlobalCodeBytes has been removed - was deprecated)
  * - `InitNetwork`: Initializes the network account and optionally creates an internal transaction receipt.
  * - `ChangeConfig`: Schedules a configuration change to be applied at a future cycle and optionally creates an internal transaction receipt.
  * - `ApplyChangeConfig`: Applies a scheduled configuration change to the network account and optionally creates an internal transaction receipt.
@@ -2820,19 +2820,7 @@ async function applyInternalTx(
   const txId = generateTxId(tx)
   const applyResponse: ShardusTypes.ApplyResponse = shardus.createApplyResponse(txId, txTimestamp)
   const internalTx = tx as InternalTx
-  if (internalTx.internalTXType === InternalTXType.SetGlobalCodeBytes) {
-    // eslint-disable-next-line security/detect-object-injection
-    const wrappedEVMAccount: WrappedEVMAccount = wrappedStates[internalTx.from].data
-    //just update the timestamp?
-    wrappedEVMAccount.timestamp = txTimestamp
-    //I think this will naturally accomplish the goal of the global update.
-
-    //need to run this to fix buffer types after serialization
-    fixDeserializedWrappedEVMAccount(wrappedEVMAccount)
-    if (ShardeumFlags.supportInternalTxReceipt) {
-      createInternalTxReceipt(shardus, applyResponse, internalTx, networkAccount, networkAccount, txTimestamp, txId)
-    }
-  }
+  // SetGlobalCodeBytes case removed - deprecated flag
 
   if (internalTx.internalTXType === InternalTXType.InitNetwork) {
     // eslint-disable-next-line security/detect-object-injection
@@ -3179,37 +3167,7 @@ async function applyDebugTx(
   /* eslint-enable security/detect-object-injection */
 }
 
-function setGlobalCodeByteUpdate(
-  txTimestamp: number,
-  wrappedEVMAccount: WrappedEVMAccount,
-  applyResponse: ShardusTypes.ApplyResponse
-): void {
-  const globalAddress = getAccountShardusAddress(wrappedEVMAccount)
-  const when = txTimestamp + 1000 * 10
-  const value = {
-    isInternalTx: true,
-    internalTXType: InternalTXType.SetGlobalCodeBytes,
-    // type: 'apply_code_bytes', //extra, for debug
-    timestamp: when,
-    accountData: wrappedEVMAccount,
-    from: globalAddress,
-  }
 
-  //value = shardus.signAsNode(value)
-
-  const addressHash = WrappedEVMAccountFunctions._calculateAccountHash(wrappedEVMAccount)
-  const afterStateHash = addressHash
-
-  const ourAppDefinedData = applyResponse.appDefinedData as OurAppDefinedData
-  ourAppDefinedData.globalMsg = {
-    address: globalAddress,
-    addressHash,
-    value,
-    when,
-    source: globalAddress,
-    afterStateHash: afterStateHash,
-  }
-}
 
 async function _transactionReceiptPass(
   tx,
@@ -5080,21 +5038,16 @@ const shardusSetup = (): void => {
         //add our codehash to the map entry for the CA address
         accountToCodeHash.set(contractByteWrite.contractAddress.toString(), contractByteWrite.codeHash)
 
-        if (ShardeumFlags.globalCodeBytes === true) {
-          //set this globally instead!
-          setGlobalCodeByteUpdate(txTimestamp, wrappedEVMAccount, applyResponse)
-        } else {
-          const wrappedChangedAccount = WrappedEVMAccountFunctions._shardusWrappedAccount(wrappedEVMAccount)
-          //attach to applyResponse
-          if (shardus.applyResponseAddChangedAccount != null) {
-            shardus.applyResponseAddChangedAccount(
-              applyResponse,
-              wrappedChangedAccount.accountId,
-              wrappedChangedAccount as ShardusTypes.WrappedResponse,
-              txId,
-              wrappedChangedAccount.timestamp
-            )
-          }
+        const wrappedChangedAccount = WrappedEVMAccountFunctions._shardusWrappedAccount(wrappedEVMAccount)
+        //attach to applyResponse
+        if (shardus.applyResponseAddChangedAccount != null) {
+          shardus.applyResponseAddChangedAccount(
+            applyResponse,
+            wrappedChangedAccount.accountId,
+            wrappedChangedAccount as ShardusTypes.WrappedResponse,
+            txId,
+            wrappedChangedAccount.timestamp
+          )
         }
       }
       /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('DBG: accountsToCodeHash', accountToCodeHash)
@@ -5684,9 +5637,7 @@ const shardusSetup = (): void => {
           allKeys: [],
           timestamp: timestamp,
         }
-        if (internalTx.internalTXType === InternalTXType.SetGlobalCodeBytes) {
-          keys.sourceKeys = [internalTx.from]
-        } else if (internalTx.internalTXType === InternalTXType.InitNetwork) {
+        if (internalTx.internalTXType === InternalTXType.InitNetwork) {
           keys.targetKeys = [networkAccount]
         } else if (internalTx.internalTXType === InternalTXType.ChangeConfig) {
           keys.sourceKeys = [tx.from]
@@ -6081,14 +6032,7 @@ const shardusSetup = (): void => {
         shardus.setDebugSetLastAppAwait('getRelevantData.AccountsStorage.getAccount 4')
         let wrappedEVMAccount: NetworkAccount | WrappedEVMAccount = await AccountsStorage.getAccount(accountId)
         shardus.setDebugSetLastAppAwait('getRelevantData.AccountsStorage.getAccount 4', DebugComplete.Completed)
-        if (internalTx.internalTXType === InternalTXType.SetGlobalCodeBytes) {
-          if (wrappedEVMAccount == null) {
-            accountCreated = true
-          }
-          if (internalTx.accountData) {
-            wrappedEVMAccount = internalTx.accountData
-          }
-        }
+        // SetGlobalCodeBytes case removed - deprecated flag
         if (internalTx.internalTXType === InternalTXType.InitNetwork) {
           if (!wrappedEVMAccount) {
             if (accountId === networkAccount) {
@@ -8252,9 +8196,7 @@ const shardusSetup = (): void => {
     getTxSenderAddress(tx) {
       if (isInternalTx(tx) || isDebugTx(tx)) {
         const internalTx = tx as InternalTx
-        if (internalTx.internalTXType === InternalTXType.SetGlobalCodeBytes) {
-          return internalTx.from
-        } else if (internalTx.internalTXType === InternalTXType.InitNetwork) {
+        if (internalTx.internalTXType === InternalTXType.InitNetwork) {
           return internalTx.network
         } else if (internalTx.internalTXType === InternalTXType.ChangeConfig) {
           return internalTx.from

--- a/src/setup/helpers.ts
+++ b/src/setup/helpers.ts
@@ -21,7 +21,7 @@ export function verify(obj: any, expectedPk?: string): boolean {
 
 export function isInternalTXGlobal(internalTx: InternalTx): boolean {
   return (
-    internalTx.internalTXType === InternalTXType.SetGlobalCodeBytes ||
+    // SetGlobalCodeBytes removed - deprecated flag
     internalTx.internalTXType === InternalTXType.ApplyChangeConfig ||
     internalTx.internalTXType === InternalTXType.InitNetwork ||
     internalTx.internalTXType === InternalTXType.ApplyNetworkParam

--- a/src/shardeum/shardeumFlags.ts
+++ b/src/shardeum/shardeumFlags.ts
@@ -4,7 +4,6 @@ export interface ShardeumFlags {
   contractStorageKeySilo: boolean
   contractStoragePrefixBitLength: number
   contractCodeKeySilo: boolean
-  globalCodeBytes: boolean
   VerboseLogs: boolean
   debugTraceLogs: boolean
   Virtual0Address: boolean
@@ -137,7 +136,6 @@ export const ShardeumFlags: ShardeumFlags = {
   contractStorageKeySilo: true,
   contractStoragePrefixBitLength: 3,
   contractCodeKeySilo: false,
-  globalCodeBytes: false,
   VerboseLogs: false,
   debugTraceLogs: false,
   Virtual0Address: true,

--- a/src/shardeum/shardeumTypes.ts
+++ b/src/shardeum/shardeumTypes.ts
@@ -92,7 +92,7 @@ export interface EVMAccountInfo {
 }
 
 export enum InternalTXType {
-  SetGlobalCodeBytes = 0, //Deprecated
+  // Value 0 was previously SetGlobalCodeBytes (removed - deprecated)
   InitNetwork = 1,
   NodeReward = 2, //Deprecated
   ChangeConfig = 3,

--- a/test/unit/src/setup/helpers.test.ts
+++ b/test/unit/src/setup/helpers.test.ts
@@ -78,10 +78,7 @@ describe('isInternalTXGlobal', () => {
     sign: { owner: 'test', sig: 'test' },
   })
 
-  it('should identify SetGlobalCodeBytes as global', () => {
-    const tx = createMockInternalTx(InternalTXType.SetGlobalCodeBytes)
-    expect(isInternalTXGlobal(tx)).toBe(true)
-  })
+  // Test for SetGlobalCodeBytes removed - deprecated flag
 
   it('should identify ApplyChangeConfig as global', () => {
     const tx = createMockInternalTx(InternalTXType.ApplyChangeConfig)

--- a/test/unit/src/shardeum/shardeumFlags.test.ts
+++ b/test/unit/src/shardeum/shardeumFlags.test.ts
@@ -36,7 +36,7 @@ describe('ShardeumFlags', () => {
       expect(ShardeumFlags.contractStorageKeySilo).toBeDefined()
       expect(ShardeumFlags.contractStoragePrefixBitLength).toBeDefined()
       expect(ShardeumFlags.contractCodeKeySilo).toBeDefined()
-      expect(ShardeumFlags.globalCodeBytes).toBeDefined()
+      // globalCodeBytes test removed - deprecated flag
       expect(ShardeumFlags.UseDBForAccounts).toBeDefined()
 
       // Network Configuration
@@ -75,7 +75,7 @@ describe('ShardeumFlags', () => {
         expect(ShardeumFlags.contractStorageKeySilo).toBe(true)
         expect(ShardeumFlags.contractStoragePrefixBitLength).toBe(3)
         expect(ShardeumFlags.contractCodeKeySilo).toBe(false)
-        expect(ShardeumFlags.globalCodeBytes).toBe(false)
+        // globalCodeBytes test removed - deprecated flag
         expect(ShardeumFlags.UseDBForAccounts).toBe(true)
       })
     })

--- a/test/unit/src/shardeum/shardeumTypes.test.ts
+++ b/test/unit/src/shardeum/shardeumTypes.test.ts
@@ -58,7 +58,7 @@ describe('shardeumTypes', () => {
 
     describe('InternalTXType', () => {
       it('should have correct values for internal transaction types', () => {
-        expect(InternalTXType.SetGlobalCodeBytes).toBe(0)
+        // Test for SetGlobalCodeBytes removed - deprecated flag
         expect(InternalTXType.InitNetwork).toBe(1)
         expect(InternalTXType.NodeReward).toBe(2)
         expect(InternalTXType.ChangeConfig).toBe(3)


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Remove deprecated `globalCodeBytes` flag and related logic

- Eliminate all code and tests for `SetGlobalCodeBytes` internal transaction type

- Update type definitions and interfaces to reflect removals

- Clean up comments and documentation referencing deprecated features


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>dupeTxNonceCheck.ts</strong><dd><code>Remove SetGlobalCodeBytes from internal TX type mapping</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/580/files#diff-603d68c99f556476b2d65ffdcf42cbe02f92d2dce55504dde67fbc0ad8503d34">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Remove all logic and references for SetGlobalCodeBytes</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/580/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+15/-73</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>helpers.ts</strong><dd><code>Remove SetGlobalCodeBytes from isInternalTXGlobal logic</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/580/files#diff-01001845d1ad6bb0f091e718516d89f88df0dbb7881952b23d986770339416c2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shardeumFlags.ts</strong><dd><code>Remove globalCodeBytes flag from interface and defaults</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/580/files#diff-53f709116ea9cfd369021621f905892d7c768eab77678888ac6f6e45a1ca3a01">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shardeumTypes.ts</strong><dd><code>Remove SetGlobalCodeBytes from InternalTXType enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/580/files#diff-93faee2660c58301297b3b056390b382899307b64599936348366ba09b5d97ff">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>helpers.test.ts</strong><dd><code>Remove tests for SetGlobalCodeBytes in isInternalTXGlobal</code></dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/580/files#diff-14719a8f5c6945047e3dc43106240d2d5669be3dd9e5bc177203a9873164020c">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shardeumFlags.test.ts</strong><dd><code>Remove tests for globalCodeBytes flag existence and default</code></dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/580/files#diff-5923ea940501da3a95aa3d918260e012e532c8bbc64df840159f8c00e41d8801">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shardeumTypes.test.ts</strong><dd><code>Remove tests for SetGlobalCodeBytes in InternalTXType</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/shardeum/pull/580/files#diff-cb204fbeab5ee1c2f56639806638c64dc0d88ab76e7952daf3b99bd71934d0fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>