### PR TITLE
Shard 2630

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2554,6 +2554,18 @@ const configShardusNetworkTransactions = (): void => {
         /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('Invalid signature for internal tx', Utils.safeStringify(tx))
         return false
       }
+      
+      // Strict schema validation - reject any extra fields
+      const allowedFields = ['publicKey', 'nodeId', 'endTime', 'sign']
+      const txKeys = Object.keys(tx)
+      for (const key of txKeys) {
+        if (!allowedFields.includes(key)) {
+          /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log(`registerBeforeAddVerifier - nodeReward: fail unexpected field ${key}`, Utils.safeStringify(tx))
+          /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `registerBeforeAddVerifier nodeReward fail unexpected field ${key}`)
+          return false
+        }
+      }
+      
       const shardusAddress = tx.publicKey?.toLowerCase()
       const account = await shardus.getLocalOrRemoteAccount(shardusAddress)
       if (!account) {
@@ -2686,6 +2698,18 @@ const configShardusNetworkTransactions = (): void => {
         /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validate nodeInitReward fail Invalid signature`)
         return false
       }
+      
+      // Strict schema validation - reject any extra fields
+      const allowedFields = ['publicKey', 'nodeId', 'startTime', 'sign']
+      const txKeys = Object.keys(tx)
+      for (const key of txKeys) {
+        if (!allowedFields.includes(key)) {
+          /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log(`registerBeforeAddVerifier - nodeInitReward: fail unexpected field ${key}`, Utils.safeStringify(tx))
+          /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `registerBeforeAddVerifier nodeInitReward fail unexpected field ${key}`)
+          return false
+        }
+      }
+      
       const shardusAddress = tx.publicKey?.toLowerCase()
       const account = await shardus.getLocalOrRemoteAccount(shardusAddress)
       if (!account) {

--- a/src/tx/claimReward.ts
+++ b/src/tx/claimReward.ts
@@ -135,19 +135,27 @@ export function validateClaimRewardTx(tx: ClaimRewardTX, shardus: Shardus): { is
     return { isValid: false, reason: 'txData not in serviceQueue for ClaimReward tx' }
   }
 
-  // Verify the transaction data structure to prevent type confusion
-  // nodeReward should have endTime field, nodeInitReward should have startTime field
-  if (!tx.txData.endTime) {
-    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateClaimRewardTx fail missing endTime`)
-    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateClaimRewardTx fail missing endTime', tx)
-    return { isValid: false, reason: 'txData must have endTime field' }
+  // Verify the transaction type in service queue
+  const latestEntry = shardus.serviceQueue.getLatestNetworkTxEntryForSubqueueKey(tx.txData.publicKey)
+  if (!latestEntry) {
+    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateClaimRewardTx fail no service queue entry found for publicKey`)
+    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateClaimRewardTx fail no service queue entry found for publicKey', tx)
+    return { isValid: false, reason: 'No service queue entry found for publicKey' }
   }
   
-  // Ensure this is not a nodeInitReward transaction (which would have startTime instead of endTime)
-  if ('startTime' in tx.txData) {
-    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateClaimRewardTx fail wrong tx type - has startTime field`)
-    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateClaimRewardTx fail wrong tx type - has startTime field', tx)
-    return { isValid: false, reason: 'Service queue tx appears to be nodeInitReward type (has startTime)' }
+  // Verify it's the same transaction by comparing hash
+  const txDataHash = crypto.hashObj(tx.txData)
+  if (latestEntry.hash !== txDataHash) {
+    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateClaimRewardTx fail transaction hash mismatch`)
+    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateClaimRewardTx fail transaction hash mismatch', tx)
+    return { isValid: false, reason: 'Transaction hash mismatch - not the same transaction' }
+  }
+  
+  // Verify correct transaction type
+  if (latestEntry.tx.type !== 'nodeReward') {
+    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateClaimRewardTx fail wrong service queue tx type: ${latestEntry.tx.type}`)
+    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateClaimRewardTx fail wrong service queue tx type', tx)
+    return { isValid: false, reason: 'Service queue tx must be nodeReward type' }
   }
 
   // check txData matches tx

--- a/src/tx/claimReward.ts
+++ b/src/tx/claimReward.ts
@@ -135,6 +135,21 @@ export function validateClaimRewardTx(tx: ClaimRewardTX, shardus: Shardus): { is
     return { isValid: false, reason: 'txData not in serviceQueue for ClaimReward tx' }
   }
 
+  // Verify the transaction data structure to prevent type confusion
+  // nodeReward should have endTime field, nodeInitReward should have startTime field
+  if (!tx.txData.endTime) {
+    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateClaimRewardTx fail missing endTime`)
+    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateClaimRewardTx fail missing endTime', tx)
+    return { isValid: false, reason: 'txData must have endTime field' }
+  }
+  
+  // Ensure this is not a nodeInitReward transaction (which would have startTime instead of endTime)
+  if ('startTime' in tx.txData) {
+    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateClaimRewardTx fail wrong tx type - has startTime field`)
+    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateClaimRewardTx fail wrong tx type - has startTime field', tx)
+    return { isValid: false, reason: 'Service queue tx appears to be nodeInitReward type (has startTime)' }
+  }
+
   // check txData matches tx
   if (tx.txData.endTime !== tx.nodeDeactivatedTime) {
     /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateClaimRewardTx fail txData.endTime does not match tx.nodeDeactivatedTime`)
@@ -259,6 +274,15 @@ export async function applyClaimRewardTx(
     //throw new Error(`applyClaimReward failed because durationInNetwork is less than or equal 0`)
     shardus.applyResponseSetFailed(applyResponse, `applyClaimReward failed because durationInNetwork is less than 0`)
     return
+  }
+  
+  // Apply maximum reward duration cap to prevent exploitation
+  const MAX_REWARD_DURATION_DAYS = 365 // 1 year maximum
+  const MAX_REWARD_DURATION_MS = MAX_REWARD_DURATION_DAYS * 24 * 60 * 60 * 1000
+  if (durationInNetwork > MAX_REWARD_DURATION_MS) {
+    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log(`Capping reward duration from ${durationInNetwork}ms to ${MAX_REWARD_DURATION_MS}ms for nominee ${tx.nominee}`)
+    nestedCountersInstance.countEvent('shardeum-staking', `applyClaimRewardTx duration capped`)
+    durationInNetwork = MAX_REWARD_DURATION_MS
   }
 
   // special case for seed nodes:

--- a/src/tx/initRewardTimes.ts
+++ b/src/tx/initRewardTimes.ts
@@ -101,19 +101,27 @@ export function validateFields(tx: InitRewardTimes, shardus: Shardus): { success
     return { success: false, reason: 'node not in serviceQueue' }
   }
   
-  // Verify the transaction data structure to prevent type confusion
-  // nodeInitReward should have startTime field, nodeReward should have endTime field
-  if (!tx.txData.startTime || tx.txData.startTime !== tx.nodeActivatedTime) {
-    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail missing or mismatched startTime', tx)
-    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail missing or mismatched startTime`)
-    return { success: false, reason: 'txData must have startTime matching nodeActivatedTime' }
+  // Verify the transaction type in service queue
+  const latestEntry = shardus.serviceQueue.getLatestNetworkTxEntryForSubqueueKey(tx.txData.publicKey)
+  if (!latestEntry) {
+    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail no service queue entry found for publicKey', tx)
+    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail no service queue entry found for publicKey`)
+    return { success: false, reason: 'No service queue entry found for publicKey' }
   }
   
-  // Ensure this is not a nodeReward transaction (which would have endTime instead of startTime)
-  if ('endTime' in tx.txData) {
-    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail wrong tx type - has endTime field', tx)
-    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail wrong tx type - has endTime field`)
-    return { success: false, reason: 'Service queue tx appears to be nodeReward type (has endTime)' }
+  // Verify it's the same transaction by comparing hash
+  const txDataHash = crypto.hashObj(tx.txData)
+  if (latestEntry.hash !== txDataHash) {
+    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail transaction hash mismatch', tx)
+    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail transaction hash mismatch`)
+    return { success: false, reason: 'Transaction hash mismatch - not the same transaction' }
+  }
+  
+  // Verify correct transaction type
+  if (latestEntry.tx.type !== 'nodeInitReward') {
+    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail wrong service queue tx type', tx)
+    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail wrong service queue tx type: ${latestEntry.tx.type}`)
+    return { success: false, reason: 'Service queue tx must be nodeInitReward type' }
   }
   
   // check txData matches tx

--- a/src/tx/initRewardTimes.ts
+++ b/src/tx/initRewardTimes.ts
@@ -100,6 +100,22 @@ export function validateFields(tx: InitRewardTimes, shardus: Shardus): { success
     /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail node not in serviceQueue`)
     return { success: false, reason: 'node not in serviceQueue' }
   }
+  
+  // Verify the transaction data structure to prevent type confusion
+  // nodeInitReward should have startTime field, nodeReward should have endTime field
+  if (!tx.txData.startTime || tx.txData.startTime !== tx.nodeActivatedTime) {
+    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail missing or mismatched startTime', tx)
+    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail missing or mismatched startTime`)
+    return { success: false, reason: 'txData must have startTime matching nodeActivatedTime' }
+  }
+  
+  // Ensure this is not a nodeReward transaction (which would have endTime instead of startTime)
+  if ('endTime' in tx.txData) {
+    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail wrong tx type - has endTime field', tx)
+    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail wrong tx type - has endTime field`)
+    return { success: false, reason: 'Service queue tx appears to be nodeReward type (has endTime)' }
+  }
+  
   // check txData matches tx
   if (tx.txData.startTime !== tx.nodeActivatedTime) {
     /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail txData.startTime does not match nodeActivatedTime', tx)
@@ -111,6 +127,18 @@ export function validateFields(tx: InitRewardTimes, shardus: Shardus): { success
     /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail txData.publicKey does not match tx.nominee', tx)
     return { success: false, reason: 'txData.publicKey does not match tx.nominee' }
   }
+  
+  // Temporal validation - verify nodeActivatedTime matches actual activation cycle
+  const latestCycles = shardus.getLatestCycles(10)
+  const activationCycle = latestCycles.find(cycle => 
+    cycle.activatedPublicKeys && cycle.activatedPublicKeys.includes(tx.nominee)
+  )
+  if (!activationCycle || activationCycle.start !== tx.nodeActivatedTime) {
+    /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail nodeActivatedTime does not match actual activation cycle', tx)
+    /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail nodeActivatedTime does not match actual activation cycle`)
+    return { success: false, reason: 'nodeActivatedTime does not match actual activation cycle' }
+  }
+  
   /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes success', tx)
   return { success: true, reason: 'valid' }
 }

--- a/test/unit/src/shardeum/claimReward.test.ts
+++ b/test/unit/src/shardeum/claimReward.test.ts
@@ -147,6 +147,7 @@ describe('claimReward', () => {
   const mockSignature = 'mockSignature'
   const mockTxId = 'mockTxId'
   const mockTimestamp = 3000 // Transaction timestamp, after endTime
+  const mockTxDataHash = 'mockTxDataHash' // Mock hash for txData
 
   // Mock objects
   let mockShardus: jest.Mocked<any>
@@ -159,6 +160,9 @@ describe('claimReward', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    
+    // Mock crypto functions
+    ;(crypto.hashObj as jest.Mock).mockReturnValue(mockTxDataHash)
 
     // Initialize mock Shardus instance
     mockShardus = {
@@ -167,6 +171,12 @@ describe('claimReward', () => {
       put: jest.fn().mockReturnValue(mockClaimRewardTx), // Return the mock tx for successful injection
       serviceQueue: {
         containsTxData: jest.fn().mockReturnValue(true),
+        getLatestNetworkTxEntryForSubqueueKey: jest.fn().mockReturnValue({
+          hash: mockTxDataHash,
+          tx: {
+            type: 'nodeReward'
+          }
+        }), // Mock service queue entry for validation
       },
       getNode: jest.fn().mockReturnValue(null), // Default to node not active
       applyResponseSetFailed: jest.fn(),

--- a/test/unit/src/shardeum/initRewardTimes.test.ts
+++ b/test/unit/src/shardeum/initRewardTimes.test.ts
@@ -49,6 +49,7 @@ describe('initRewardTimes', () => {
   const mockSignature = 'mockSignature'
   const mockTxId = 'mockTxId'
   const mockTimestamp = 2000 // Transaction timestamp, after startTime
+  const mockTxDataHash = 'mockTxDataHash' // Mock hash for txData
 
   // Mock objects for testing
   let mockShardus: jest.Mocked<any>
@@ -60,6 +61,9 @@ describe('initRewardTimes', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    
+    // Mock crypto functions
+    ;(crypto.hashObj as jest.Mock).mockReturnValue(mockTxDataHash)
 
     // Initialize mock Shardus instance with required methods
     mockShardus = {
@@ -68,9 +72,21 @@ describe('initRewardTimes', () => {
       put: jest.fn(), // For submitting transactions
       serviceQueue: {
         containsTxData: jest.fn().mockReturnValue(true), // Default to valid service queue state
+        getLatestNetworkTxEntryForSubqueueKey: jest.fn().mockReturnValue({
+          hash: mockTxDataHash,
+          tx: {
+            type: 'nodeInitReward'
+          }
+        }), // Mock service queue entry for validation
       },
       applyResponseSetFailed: jest.fn(), // For handling failed transactions
       applyResponseAddChangedAccount: jest.fn(), // For recording account state changes
+      getLatestCycles: jest.fn().mockReturnValue([
+        {
+          start: 1000,
+          activatedPublicKeys: [mockPublicKey]
+        }
+      ]), // Mock cycle data for temporal validation
     }
 
     // Initialize mock node account statistics

--- a/test/unit/src/shardeum/initRewardValidateTx.test.ts
+++ b/test/unit/src/shardeum/initRewardValidateTx.test.ts
@@ -153,6 +153,11 @@ describe('validateFields', () => {
       },
     }
     ;(shardeumGetTime as jest.Mock).mockReturnValue(1752480455000)
+    // Update mock to handle this specific tx
+    mockShardus.getLatestCycles.mockReturnValue([{
+      start: 1752480275,
+      activatedPublicKeys: ['162c15ef77dece29ee9f46b333dc8de5167102be485034986aa0318c42951a2a']
+    }])
     expect(validateFields(tx as any, mockShardus)).toEqual({ success: true, reason: 'valid' })
   })
 })

--- a/test/unit/src/shardeum/initRewardValidateTx.test.ts
+++ b/test/unit/src/shardeum/initRewardValidateTx.test.ts
@@ -29,13 +29,28 @@ describe('validateFields', () => {
   }
   let mockShardus: any
   let verifyObjMock
+  const mockTxDataHash = 'mockTxDataHash'
+  
   beforeEach(() => {
     jest.clearAllMocks()
     ;(shardeumGetTime as jest.Mock).mockReturnValue(1720938700000)
+    ;(crypto.hashObj as jest.Mock).mockReturnValue(mockTxDataHash)
     mockShardus = {
       serviceQueue: {
         containsTxData: jest.fn(() => true),
+        getLatestNetworkTxEntryForSubqueueKey: jest.fn().mockReturnValue({
+          hash: mockTxDataHash,
+          tx: {
+            type: 'nodeInitReward'
+          }
+        }),
       },
+      getLatestCycles: jest.fn().mockReturnValue([
+        {
+          start: 1720938699,
+          activatedPublicKeys: ['a'.repeat(64)]
+        }
+      ]),
     }
     verifyObjMock = jest.spyOn(crypto, 'verifyObj').mockReturnValue(true)
   })

--- a/test/unit/src/shardeum/rewardSystemSecurity.test.ts
+++ b/test/unit/src/shardeum/rewardSystemSecurity.test.ts
@@ -1,0 +1,371 @@
+import { nestedCountersInstance } from '@shardeum-foundation/core'
+import * as crypto from '@shardeum-foundation/lib-crypto-utils'
+import { SignedNodeRewardTxData, SignedNodeInitTxData } from '../../../../src/shardeum/shardeumTypes'
+import { validateFields as validateInitRewardFields } from '../../../../src/tx/initRewardTimes'
+import { validateClaimRewardTx } from '../../../../src/tx/claimReward'
+
+// Mock crypto module
+crypto.init('69fa4195670576c0160d660c3be36556ff8d504725be8a59b5a96509e0c994bc')
+
+// Mock shardus instance
+const createMockShardus = () => ({
+  serviceQueue: {
+    containsTxData: jest.fn(),
+    getLatestNetworkTxEntryForSubqueueKey: jest.fn(),
+  },
+  getLatestCycles: jest.fn(),
+  getRemovedNodePubKeyFromCache: jest.fn(),
+  getNode: jest.fn(),
+  getLocalOrRemoteAccount: jest.fn(),
+})
+
+describe('Reward System Security Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Service Queue Schema Validation', () => {
+    it('should reject nodeReward transaction with extra fields', () => {
+      const maliciousTx: SignedNodeRewardTxData & { startTime?: number } = {
+        publicKey: '0'.repeat(64),
+        nodeId: '1'.repeat(64),
+        endTime: Date.now(),
+        startTime: 946684800000, // Year 2000 - malicious extra field
+        sign: {
+          owner: '0'.repeat(64),
+          sig: 'valid_signature',
+        },
+      }
+
+      // The validation should detect and reject the extra field
+      const txKeys = Object.keys(maliciousTx)
+      const allowedFields = ['publicKey', 'nodeId', 'endTime', 'sign']
+      
+      let hasExtraFields = false
+      for (const key of txKeys) {
+        if (!allowedFields.includes(key)) {
+          hasExtraFields = true
+          break
+        }
+      }
+      
+      expect(hasExtraFields).toBe(true)
+    })
+
+    it('should reject nodeInitReward transaction with extra fields', () => {
+      const maliciousTx: SignedNodeInitTxData & { endTime?: number } = {
+        publicKey: '0'.repeat(64),
+        nodeId: '1'.repeat(64),
+        startTime: Date.now(),
+        endTime: Date.now() + 1000000, // Malicious extra field
+        sign: {
+          owner: '0'.repeat(64),
+          sig: 'valid_signature',
+        },
+      }
+
+      const txKeys = Object.keys(maliciousTx)
+      const allowedFields = ['publicKey', 'nodeId', 'startTime', 'sign']
+      
+      let hasExtraFields = false
+      for (const key of txKeys) {
+        if (!allowedFields.includes(key)) {
+          hasExtraFields = true
+          break
+        }
+      }
+      
+      expect(hasExtraFields).toBe(true)
+    })
+  })
+
+  describe('Transaction Type Validation', () => {
+    it('should reject InitRewardTimes with wrong service queue tx type', () => {
+      const mockShardus = createMockShardus()
+      
+      const txData = {
+        publicKey: '0'.repeat(64),
+        nodeId: '1'.repeat(64),
+        startTime: Date.now(),
+        sign: {
+          owner: '0'.repeat(64),
+          sig: 'valid_signature',
+        },
+      }
+      
+      const txDataHash = crypto.hashObj(txData)
+      
+      // Mock service queue to contain the tx
+      mockShardus.serviceQueue.containsTxData.mockReturnValue(true)
+      
+      // Mock getting wrong transaction type from service queue
+      mockShardus.serviceQueue.getLatestNetworkTxEntryForSubqueueKey.mockReturnValue({
+        hash: txDataHash,
+        tx: {
+          type: 'nodeReward', // Wrong type - should be nodeInitReward
+          hash: txDataHash,
+          txData: txData,
+          cycle: 1,
+          priority: 0,
+          subQueueKey: txData.publicKey,
+        },
+      })
+
+      const tx = {
+        isInternalTx: true,
+        internalTXType: 0,
+        nominee: '0'.repeat(64),
+        nodeActivatedTime: Date.now(),
+        timestamp: Date.now(),
+        txData: txData,
+        sign: {
+          owner: '0'.repeat(64),
+          sig: 'valid_signature',
+        },
+      }
+
+      const result = validateInitRewardFields(tx as any, mockShardus as any)
+      expect(result.success).toBe(false)
+      expect(result.reason).toContain('Service queue tx must be nodeInitReward type')
+    })
+
+    it('should reject ClaimReward with wrong service queue tx type', () => {
+      const mockShardus = createMockShardus()
+      
+      const txData = {
+        publicKey: '0'.repeat(64),
+        nodeId: '1'.repeat(64),
+        endTime: Date.now(),
+        sign: {
+          owner: '0'.repeat(64),
+          sig: 'valid_signature',
+        },
+      }
+      
+      const txDataHash = crypto.hashObj(txData)
+      
+      // Mock service queue to contain the tx
+      mockShardus.serviceQueue.containsTxData.mockReturnValue(true)
+      
+      // Mock getting wrong transaction type from service queue
+      mockShardus.serviceQueue.getLatestNetworkTxEntryForSubqueueKey.mockReturnValue({
+        hash: txDataHash,
+        tx: {
+          type: 'nodeInitReward', // Wrong type - should be nodeReward
+          hash: txDataHash,
+          txData: txData,
+          cycle: 1,
+          priority: 0,
+          subQueueKey: txData.publicKey,
+        },
+      })
+
+      const tx = {
+        nominee: '0'.repeat(64),
+        nominator: '0x' + '2'.repeat(40),
+        timestamp: Date.now(),
+        deactivatedNodeId: '1'.repeat(64),
+        nodeDeactivatedTime: Date.now(),
+        cycle: 1,
+        isInternalTx: true,
+        internalTXType: 1,
+        txData: txData,
+        sign: {
+          owner: '0'.repeat(64),
+          sig: 'valid_signature',
+        },
+      }
+
+      const result = validateClaimRewardTx(tx as any, mockShardus as any)
+      expect(result.isValid).toBe(false)
+      expect(result.reason).toContain('Service queue tx must be nodeReward type')
+    })
+  })
+
+  describe('Temporal Validation', () => {
+    it('should reject InitRewardTimes with fake activation time', () => {
+      const mockShardus = createMockShardus()
+      
+      // Mock cycles - node was activated at a specific time
+      const realActivationTime = Date.now() - 86400000 // 1 day ago
+      mockShardus.getLatestCycles.mockReturnValue([
+        {
+          start: realActivationTime,
+          activatedPublicKeys: ['0'.repeat(64)],
+        },
+      ])
+      
+      const txData = {
+        publicKey: '0'.repeat(64),
+        nodeId: '1'.repeat(64),
+        startTime: 946684800000, // Year 2000 - fake time
+        sign: {
+          owner: '0'.repeat(64),
+          sig: 'valid_signature',
+        },
+      }
+      
+      const txDataHash = crypto.hashObj(txData)
+      
+      mockShardus.serviceQueue.containsTxData.mockReturnValue(true)
+      mockShardus.serviceQueue.getLatestNetworkTxEntryForSubqueueKey.mockReturnValue({
+        hash: txDataHash,
+        tx: {
+          type: 'nodeInitReward',
+          hash: txDataHash,
+          txData: txData,
+          cycle: 1,
+          priority: 0,
+          subQueueKey: txData.publicKey,
+        },
+      })
+
+      const tx = {
+        isInternalTx: true,
+        internalTXType: 0,
+        nominee: '0'.repeat(64),
+        nodeActivatedTime: 946684800000, // Year 2000 - fake time
+        timestamp: Date.now(),
+        txData: txData,
+        sign: {
+          owner: '0'.repeat(64),
+          sig: 'valid_signature',
+        },
+      }
+
+      const result = validateInitRewardFields(tx as any, mockShardus as any)
+      expect(result.success).toBe(false)
+      expect(result.reason).toContain('nodeActivatedTime does not match actual activation cycle')
+    })
+    
+    it('should reject InitRewardTimes with hash mismatch', () => {
+      const mockShardus = createMockShardus()
+      
+      const txData = {
+        publicKey: '0'.repeat(64),
+        nodeId: '1'.repeat(64),
+        startTime: Date.now(),
+        sign: {
+          owner: '0'.repeat(64),
+          sig: 'valid_signature',
+        },
+      }
+      
+      const txDataHash = crypto.hashObj(txData)
+      
+      mockShardus.serviceQueue.containsTxData.mockReturnValue(true)
+      
+      // Mock returning a different transaction (different hash)
+      mockShardus.serviceQueue.getLatestNetworkTxEntryForSubqueueKey.mockReturnValue({
+        hash: 'different_hash_12345',
+        tx: {
+          type: 'nodeInitReward',
+          hash: 'different_hash_12345',
+          txData: { /* different txData */ },
+          cycle: 1,
+          priority: 0,
+          subQueueKey: txData.publicKey,
+        },
+      })
+
+      const tx = {
+        isInternalTx: true,
+        internalTXType: 0,
+        nominee: '0'.repeat(64),
+        nodeActivatedTime: Date.now(),
+        timestamp: Date.now(),
+        txData: txData,
+        sign: {
+          owner: '0'.repeat(64),
+          sig: 'valid_signature',
+        },
+      }
+
+      const result = validateInitRewardFields(tx as any, mockShardus as any)
+      expect(result.success).toBe(false)
+      expect(result.reason).toContain('Transaction hash mismatch')
+    })
+  })
+
+  describe('Reward Duration Cap', () => {
+    it('should cap rewards at maximum duration', () => {
+      const MAX_REWARD_DURATION_DAYS = 365
+      const MAX_REWARD_DURATION_MS = MAX_REWARD_DURATION_DAYS * 24 * 60 * 60 * 1000
+
+      // Simulate 24 years duration attack
+      const fakeStartTime = 946684800000 // Year 2000
+      const currentTime = Date.now()
+      const maliciousDuration = currentTime - fakeStartTime
+
+      expect(maliciousDuration).toBeGreaterThan(MAX_REWARD_DURATION_MS)
+
+      // Apply the cap
+      const cappedDuration = maliciousDuration > MAX_REWARD_DURATION_MS 
+        ? MAX_REWARD_DURATION_MS 
+        : maliciousDuration
+
+      expect(cappedDuration).toBe(MAX_REWARD_DURATION_MS)
+      expect(cappedDuration).toBeLessThan(maliciousDuration)
+    })
+  })
+
+  describe('Complete Attack Scenario', () => {
+    it('should prevent the complete reward manipulation attack', () => {
+      const mockShardus = createMockShardus()
+      
+      // Step 1: Attacker tries to add nodeReward with startTime
+      const maliciousNodeReward = {
+        publicKey: '0'.repeat(64),
+        nodeId: '1'.repeat(64),
+        endTime: Date.now(),
+        startTime: 946684800000, // Extra field - should be rejected
+        sign: {
+          owner: '0'.repeat(64),
+          sig: 'valid_signature',
+        },
+      }
+
+      // Check schema validation
+      const allowedFields = ['publicKey', 'nodeId', 'endTime', 'sign']
+      const hasStartTime = 'startTime' in maliciousNodeReward
+      expect(hasStartTime).toBe(true)
+      
+      // This would be rejected by schema validation
+      const txKeys = Object.keys(maliciousNodeReward)
+      const invalidField = txKeys.find(key => !allowedFields.includes(key))
+      expect(invalidField).toBe('startTime')
+
+      // Even if it somehow passed, InitRewardTimes would reject it due to type mismatch
+      mockShardus.serviceQueue.containsTxData.mockReturnValue(true)
+      
+      const maliciousHash = crypto.hashObj(maliciousNodeReward)
+      mockShardus.serviceQueue.getLatestNetworkTxEntryForSubqueueKey.mockReturnValue({
+        hash: maliciousHash,
+        tx: {
+          type: 'nodeReward', // Wrong type for InitRewardTimes
+          hash: maliciousHash,
+          txData: maliciousNodeReward,
+          cycle: 1,
+          priority: 0,
+          subQueueKey: maliciousNodeReward.publicKey,
+        },
+      })
+
+      const initRewardTx = {
+        isInternalTx: true,
+        internalTXType: 0,
+        nominee: '0'.repeat(64),
+        nodeActivatedTime: 946684800000,
+        timestamp: Date.now(),
+        txData: maliciousNodeReward,
+        sign: {
+          owner: '0'.repeat(64),
+          sig: 'valid_signature',
+        },
+      }
+
+      const result = validateInitRewardFields(initRewardTx as any, mockShardus as any)
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/test/unit/src/shardeum/rewardSystemSecurity.test.ts
+++ b/test/unit/src/shardeum/rewardSystemSecurity.test.ts
@@ -4,8 +4,22 @@ import { SignedNodeRewardTxData, SignedNodeInitTxData } from '../../../../src/sh
 import { validateFields as validateInitRewardFields } from '../../../../src/tx/initRewardTimes'
 import { validateClaimRewardTx } from '../../../../src/tx/claimReward'
 
-// Mock crypto module
-crypto.init('69fa4195670576c0160d660c3be36556ff8d504725be8a59b5a96509e0c994bc')
+// Mock modules
+jest.mock('@shardeum-foundation/core')
+jest.mock('@shardeum-foundation/lib-crypto-utils')
+jest.mock('../../../../src/index', () => ({
+  shardeumGetTime: jest.fn(() => Date.now()),
+}))
+
+// Initialize mocked crypto functions
+const mockHashObj = jest.fn()
+const mockVerifyObj = jest.fn()
+;(crypto.hashObj as jest.Mock) = mockHashObj
+;(crypto.verifyObj as jest.Mock) = mockVerifyObj
+;(crypto.init as jest.Mock) = jest.fn()
+
+// Set up global mocks
+global.ShardeumFlags = { VerboseLogs: false }
 
 // Mock shardus instance
 const createMockShardus = () => ({
@@ -22,6 +36,9 @@ const createMockShardus = () => ({
 describe('Reward System Security Tests', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    // Set default return values for mocked crypto functions
+    mockHashObj.mockReturnValue('mockTxDataHash')
+    mockVerifyObj.mockReturnValue(true)
   })
 
   describe('Service Queue Schema Validation', () => {
@@ -93,7 +110,7 @@ describe('Reward System Security Tests', () => {
         },
       }
       
-      const txDataHash = crypto.hashObj(txData)
+      const txDataHash = 'mockTxDataHash'
       
       // Mock service queue to contain the tx
       mockShardus.serviceQueue.containsTxData.mockReturnValue(true)
@@ -142,7 +159,7 @@ describe('Reward System Security Tests', () => {
         },
       }
       
-      const txDataHash = crypto.hashObj(txData)
+      const txDataHash = 'mockTxDataHash'
       
       // Mock service queue to contain the tx
       mockShardus.serviceQueue.containsTxData.mockReturnValue(true)
@@ -205,9 +222,13 @@ describe('Reward System Security Tests', () => {
         },
       }
       
-      const txDataHash = crypto.hashObj(txData)
+      const txDataHash = 'mockTxDataHash'
       
       mockShardus.serviceQueue.containsTxData.mockReturnValue(true)
+      mockShardus.getLatestCycles.mockReturnValue([{
+        start: 946684800000,
+        activatedPublicKeys: []
+      }])
       mockShardus.serviceQueue.getLatestNetworkTxEntryForSubqueueKey.mockReturnValue({
         hash: txDataHash,
         tx: {
@@ -251,9 +272,13 @@ describe('Reward System Security Tests', () => {
         },
       }
       
-      const txDataHash = crypto.hashObj(txData)
+      const txDataHash = 'mockTxDataHash'
       
       mockShardus.serviceQueue.containsTxData.mockReturnValue(true)
+      mockShardus.getLatestCycles.mockReturnValue([{
+        start: Date.now(),
+        activatedPublicKeys: ['0'.repeat(64)]
+      }])
       
       // Mock returning a different transaction (different hash)
       mockShardus.serviceQueue.getLatestNetworkTxEntryForSubqueueKey.mockReturnValue({
@@ -337,8 +362,12 @@ describe('Reward System Security Tests', () => {
 
       // Even if it somehow passed, InitRewardTimes would reject it due to type mismatch
       mockShardus.serviceQueue.containsTxData.mockReturnValue(true)
+      mockShardus.getLatestCycles.mockReturnValue([{
+        start: 946684800000,
+        activatedPublicKeys: ['0'.repeat(64)]
+      }])
       
-      const maliciousHash = crypto.hashObj(maliciousNodeReward)
+      const maliciousHash = 'maliciousTxHash'
       mockShardus.serviceQueue.getLatestNetworkTxEntryForSubqueueKey.mockReturnValue({
         hash: maliciousHash,
         tx: {


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enforced strict schema validation for node reward transactions

- Added type checks to prevent transaction confusion (nodeReward vs nodeInitReward)

- Capped maximum reward duration to prevent exploitation

- Improved temporal validation for node activation cycles


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Strict schema validation for node reward transactions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.ts

<li>Enforced strict schema validation for <code>nodeReward</code> and <code>nodeInitReward</code> <br>transactions by rejecting extra fields<br> <li> Improved logging and event counting for unexpected transaction fields


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/582/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claimReward.ts</strong><dd><code>Type checks and reward duration cap for claimReward transactions</code></dd></summary>
<hr>

src/tx/claimReward.ts

<li>Added checks to ensure correct transaction type (nodeReward vs <br>nodeInitReward)<br> <li> Enforced presence of <code>endTime</code> and absence of <code>startTime</code> in claim reward <br>transactions<br> <li> Capped maximum reward duration to 1 year to prevent abuse<br> <li> Improved logging and event counting for validation failures


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/582/files#diff-bb04a49d4b22f7daaa3c18fa4224d54cd90dfc918aa4fd8d640cceee5259bc16">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>initRewardTimes.ts</strong><dd><code>Type and temporal validation for initRewardTimes transactions</code></dd></summary>
<hr>

src/tx/initRewardTimes.ts

<li>Added type checks to ensure correct transaction structure (presence of <br><code>startTime</code>, absence of <code>endTime</code>)<br> <li> Enforced that <code>startTime</code> matches <code>nodeActivatedTime</code><br> <li> Added temporal validation to ensure activation time matches actual <br>cycle<br> <li> Improved logging and event counting for validation failures


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/582/files#diff-dd98aa8ec8256eaec054173b1cacc1c9d73d68379879f6c947d7384fc9228466">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>