### PR TITLE
Shard 2621

### DIFF
--- a/src/evm_v2/precompiles/02-sha256.ts
+++ b/src/evm_v2/precompiles/02-sha256.ts
@@ -22,18 +22,18 @@ export function precompile02(opts: PrecompileInput): ExecResult {
 
   if (opts.gasLimit < gasUsed) {
     if (opts._debug !== undefined) {
-      opts._debug(`KECCAK256 (0x02) failed: OOG`)
+      opts._debug(`SHA256 (0x02) failed: OOG`)
     }
     return OOGResult(opts.gasLimit)
   }
 
   const hash = sha256(data)
   if (opts._debug !== undefined) {
-    opts._debug(`KECCAK256 (0x02) return hash=${bytesToHex(hash)}`)
+    opts._debug(`SHA256 (0x02) return hash=${bytesToHex(hash)}`)
   }
 
   return {
     executionGasUsed: gasUsed,
-    returnValue: sha256(data),
+    returnValue: hash,
   }
 }

--- a/src/evm_v2/precompiles/02-sha256.ts
+++ b/src/evm_v2/precompiles/02-sha256.ts
@@ -14,7 +14,7 @@ export function precompile02(opts: PrecompileInput): ExecResult {
 
   if (opts._debug !== undefined) {
     opts._debug(
-      `Run KECCAK256 (0x02) precompile data=${short(opts.data)} length=${opts.data.length} gasLimit=${
+      `Run SHA256 (0x02) precompile data=${short(opts.data)} length=${opts.data.length} gasLimit=${
         opts.gasLimit
       } gasUsed=${gasUsed}`
     )

--- a/test/unit/src/evm_v2/precompiles/02-sha256.test.ts
+++ b/test/unit/src/evm_v2/precompiles/02-sha256.test.ts
@@ -87,7 +87,7 @@ describe('SHA256 (0x02) Precompile', () => {
       const result = precompile02(input)
 
       expect(result).toEqual(OOGResult(BigInt(71)))
-      expect(mockDebug).toHaveBeenCalledWith('KECCAK256 (0x02) failed: OOG')
+      expect(mockDebug).toHaveBeenCalledWith('SHA256 (0x02) failed: OOG')
     })
 
     it('should handle exact gas limit', () => {
@@ -220,10 +220,10 @@ describe('SHA256 (0x02) Precompile', () => {
       const result = precompile02(input)
 
       expect(mockDebug).toHaveBeenCalledWith(
-        expect.stringContaining('Run KECCAK256 (0x02) precompile')
+        expect.stringContaining('Run SHA256 (0x02) precompile')
       )
       expect(mockDebug).toHaveBeenCalledWith(
-        expect.stringContaining('KECCAK256 (0x02) return hash=')
+        expect.stringContaining('SHA256 (0x02) return hash=')
       )
       // Note: The debug messages incorrectly say KECCAK256 instead of SHA256
     })

--- a/test/unit/src/shardeum/shardeumFlags.test.ts
+++ b/test/unit/src/shardeum/shardeumFlags.test.ts
@@ -271,7 +271,7 @@ describe('ShardeumFlags', () => {
         expect(ShardeumFlags.AppliedTxsMaps).toBe(false)
         expect(ShardeumFlags.SaveEVMTries).toBe(false)
         expect(ShardeumFlags.CheckpointRevertSupport).toBe(true)
-        // Removed test for disableSmartContractEndpoints as it has been replaced by network parameter smartContractSupport
+        expect(ShardeumFlags.disableSmartContractEndpoints).toBe(true)
         expect(ShardeumFlags.accessListSizeLimit).toBe(5)
       })
     })

--- a/test/unit/src/shardeum/shardeumFlags.test.ts
+++ b/test/unit/src/shardeum/shardeumFlags.test.ts
@@ -271,7 +271,7 @@ describe('ShardeumFlags', () => {
         expect(ShardeumFlags.AppliedTxsMaps).toBe(false)
         expect(ShardeumFlags.SaveEVMTries).toBe(false)
         expect(ShardeumFlags.CheckpointRevertSupport).toBe(true)
-        expect(ShardeumFlags.disableSmartContractEndpoints).toBe(true)
+        // Removed test for disableSmartContractEndpoints as it has been replaced by network parameter smartContractSupport
         expect(ShardeumFlags.accessListSizeLimit).toBe(5)
       })
     })


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed incorrect debug logging in SHA256 precompile implementation

- Corrected return value assignment in SHA256 precompile

- Restored and updated unit test for `disableSmartContractEndpoints` flag


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>02-sha256.ts</strong><dd><code>Correct SHA256 precompile logging and return value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/evm_v2/precompiles/02-sha256.ts

<li>Replaced incorrect KECCAK256 debug logs with SHA256 logs<br> <li> Fixed return value to use precomputed hash variable<br> <li> Improved debug output consistency for SHA256 precompile


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/585/files#diff-64a1ff2a707e10f62cfff221320c46bb3f956e0d6a8b6201059f95a82a0b3ebe">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shardeumFlags.test.ts</strong><dd><code>Restore and update ShardeumFlags miscellaneous settings test</code></dd></summary>
<hr>

test/unit/src/shardeum/shardeumFlags.test.ts

<li>Restored test for <code>disableSmartContractEndpoints</code> default value<br> <li> Updated comment to reflect current flag usage


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/585/files#diff-5923ea940501da3a95aa3d918260e012e532c8bbc64df840159f8c00e41d8801">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>