### PR TITLE
SHARD-2707 - Reduce the default stake lock time for new networks to 30m.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2554,7 +2554,7 @@ const configShardusNetworkTransactions = (): void => {
         /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('Invalid signature for internal tx', Utils.safeStringify(tx))
         return false
       }
-      
+
       // Strict schema validation - reject any extra fields
       const allowedFields = ['publicKey', 'nodeId', 'endTime', 'sign']
       const txKeys = Object.keys(tx)
@@ -2565,7 +2565,7 @@ const configShardusNetworkTransactions = (): void => {
           return false
         }
       }
-      
+
       const shardusAddress = tx.publicKey?.toLowerCase()
       const account = await shardus.getLocalOrRemoteAccount(shardusAddress)
       if (!account) {
@@ -2698,7 +2698,7 @@ const configShardusNetworkTransactions = (): void => {
         /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validate nodeInitReward fail Invalid signature`)
         return false
       }
-      
+
       // Strict schema validation - reject any extra fields
       const allowedFields = ['publicKey', 'nodeId', 'startTime', 'sign']
       const txKeys = Object.keys(tx)
@@ -2709,7 +2709,7 @@ const configShardusNetworkTransactions = (): void => {
           return false
         }
       }
-      
+
       const shardusAddress = tx.publicKey?.toLowerCase()
       const account = await shardus.getLocalOrRemoteAccount(shardusAddress)
       if (!account) {

--- a/src/shardeum/initialNetworkParameters.ts
+++ b/src/shardeum/initialNetworkParameters.ts
@@ -46,7 +46,8 @@ export const initialNetworkParamters: NetworkParameters = {
     nodeRefutedPenaltyPercent: 0.2,
   },
   enableRPCEndpoints: false,
-  stakeLockTime: 1000 * 60 * 60 * 24 * 14, // 1000 ms * 60s * 60m * 24h * 14d = 2 weeks in ms
+  stakeLockTime: 1000 * 60 * 30, // 1000 ms * 60s * 30m = 30 minutes in ms
+  //stakeLockTime: 1000 * 60 * 60 * 24 * 14, // 1000 ms * 60s * 60m * 24h * 14d = 2 weeks in ms
   chainID: ShardeumFlags.ChainID, // 8082
   smartContractSupport: false,
 }

--- a/src/tx/claimReward.ts
+++ b/src/tx/claimReward.ts
@@ -142,7 +142,7 @@ export function validateClaimRewardTx(tx: ClaimRewardTX, shardus: Shardus): { is
     /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateClaimRewardTx fail no service queue entry found for publicKey', tx)
     return { isValid: false, reason: 'No service queue entry found for publicKey' }
   }
-  
+
   // Verify it's the same transaction by comparing hash
   const txDataHash = crypto.hashObj(tx.txData)
   if (latestEntry.hash !== txDataHash) {
@@ -150,7 +150,7 @@ export function validateClaimRewardTx(tx: ClaimRewardTX, shardus: Shardus): { is
     /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateClaimRewardTx fail transaction hash mismatch', tx)
     return { isValid: false, reason: 'Transaction hash mismatch - not the same transaction' }
   }
-  
+
   // Verify correct transaction type
   if (latestEntry.tx.type !== 'nodeReward') {
     /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateClaimRewardTx fail wrong service queue tx type: ${latestEntry.tx.type}`)
@@ -283,7 +283,7 @@ export async function applyClaimRewardTx(
     shardus.applyResponseSetFailed(applyResponse, `applyClaimReward failed because durationInNetwork is less than 0`)
     return
   }
-  
+
   // Apply maximum reward duration cap to prevent exploitation
   const MAX_REWARD_DURATION_DAYS = 365 // 1 year maximum
   const MAX_REWARD_DURATION_MS = MAX_REWARD_DURATION_DAYS * 24 * 60 * 60 * 1000

--- a/src/tx/initRewardTimes.ts
+++ b/src/tx/initRewardTimes.ts
@@ -100,7 +100,7 @@ export function validateFields(tx: InitRewardTimes, shardus: Shardus): { success
     /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail node not in serviceQueue`)
     return { success: false, reason: 'node not in serviceQueue' }
   }
-  
+
   // Verify the transaction type in service queue
   const latestEntry = shardus.serviceQueue.getLatestNetworkTxEntryForSubqueueKey(tx.txData.publicKey)
   if (!latestEntry) {
@@ -108,7 +108,7 @@ export function validateFields(tx: InitRewardTimes, shardus: Shardus): { success
     /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail no service queue entry found for publicKey`)
     return { success: false, reason: 'No service queue entry found for publicKey' }
   }
-  
+
   // Verify it's the same transaction by comparing hash
   const txDataHash = crypto.hashObj(tx.txData)
   if (latestEntry.hash !== txDataHash) {
@@ -116,14 +116,14 @@ export function validateFields(tx: InitRewardTimes, shardus: Shardus): { success
     /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail transaction hash mismatch`)
     return { success: false, reason: 'Transaction hash mismatch - not the same transaction' }
   }
-  
+
   // Verify correct transaction type
   if (latestEntry.tx.type !== 'nodeInitReward') {
     /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail wrong service queue tx type', tx)
     /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail wrong service queue tx type: ${latestEntry.tx.type}`)
     return { success: false, reason: 'Service queue tx must be nodeInitReward type' }
   }
-  
+
   // check txData matches tx
   if (tx.txData.startTime !== tx.nodeActivatedTime) {
     /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail txData.startTime does not match nodeActivatedTime', tx)
@@ -135,18 +135,18 @@ export function validateFields(tx: InitRewardTimes, shardus: Shardus): { success
     /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail txData.publicKey does not match tx.nominee', tx)
     return { success: false, reason: 'txData.publicKey does not match tx.nominee' }
   }
-  
+
   // Temporal validation - verify nodeActivatedTime matches actual activation cycle
   const latestCycles = shardus.getLatestCycles(10)
-  const activationCycle = latestCycles.find(cycle => 
-    cycle.activatedPublicKeys && cycle.activatedPublicKeys.includes(tx.nominee)
+  const activationCycle = latestCycles.find(
+    (cycle) => cycle.activatedPublicKeys && cycle.activatedPublicKeys.includes(tx.nominee)
   )
   if (!activationCycle || activationCycle.start !== tx.nodeActivatedTime) {
     /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes fail nodeActivatedTime does not match actual activation cycle', tx)
     /* prettier-ignore */ nestedCountersInstance.countEvent('shardeum-staking', `validateFields InitRewardTimes fail nodeActivatedTime does not match actual activation cycle`)
     return { success: false, reason: 'nodeActivatedTime does not match actual activation cycle' }
   }
-  
+
   /* prettier-ignore */ if (ShardeumFlags.VerboseLogs) console.log('validateFields InitRewardTimes success', tx)
   return { success: true, reason: 'valid' }
 }

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -1,4 +1,12 @@
-import { Transaction, TransactionType, TypedTransaction, LegacyTransaction, AccessListEIP2930Transaction, FeeMarketEIP1559Transaction, BlobEIP4844Transaction } from '@ethereumjs/tx'
+import {
+  Transaction,
+  TransactionType,
+  TypedTransaction,
+  LegacyTransaction,
+  AccessListEIP2930Transaction,
+  FeeMarketEIP1559Transaction,
+  BlobEIP4844Transaction,
+} from '@ethereumjs/tx'
 import { Address } from '@ethereumjs/util'
 import { getSenderAddress } from '@shardeum-foundation/lib-net'
 import { hashSignedObj } from '../setup/helpers'

--- a/test/unit/src/shardeum/initialNetworkParameters.test.ts
+++ b/test/unit/src/shardeum/initialNetworkParameters.test.ts
@@ -125,7 +125,7 @@ describe('Initial Network Parameters', () => {
       expect(initialNetworkParamters.certCycleDuration).toBe(30)
       expect(initialNetworkParamters.enableNodeSlashing).toBe(false)
       expect(initialNetworkParamters.enableRPCEndpoints).toBe(false)
-      expect(initialNetworkParamters.stakeLockTime).toBe(1000 * 60 * 60 * 24 * 14)
+      expect(initialNetworkParamters.stakeLockTime).toBe(1000 * 60 * 30)
       expect(initialNetworkParamters.chainID).toBe(ShardeumFlags.ChainID)
     })
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Reduced the default `stakeLockTime` from 2 weeks to 30 minutes

- Updated inline comment to reflect new lock time calculation

- Retained previous value as a commented-out reference


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>initialNetworkParameters.ts</strong><dd><code>Lowered default stake lock time and updated comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/shardeum/initialNetworkParameters.ts

<li>Changed <code>stakeLockTime</code> from 2 weeks to 30 minutes<br> <li> Updated comment to match new value<br> <li> Added previous value as a commented-out line for reference


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/587/files#diff-a8d74105966a0ee68fdc5fb835c0759fb54d8ff2ab0e76f17c0e2538153555b7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>