### PR TITLE
Fix storage miss bug, checkpoint and revert methods in transaction state

### DIFF
--- a/src/debug/state/shardeumState.ts
+++ b/src/debug/state/shardeumState.ts
@@ -405,7 +405,7 @@ export default class ShardeumState implements EVMStateManagerInterface {
 
     if (this._transactionState != null) {
       //side run system on the side for now
-      this._transactionState.putContractStorage(address, key, value)
+      await this._transactionState.putContractStorage(address, key, value)
     }
     return
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4486,6 +4486,7 @@ async function fetchAndCacheAccountData(
   } catch (er) {
     const elapsed = Date.now() - startTime
     warmupStats.accReqErr++
+    warmupCache.set(shardusAddress, undefined)
     nestedCountersInstance.countEvent('aalg-warmup', `account er: ${er.message}`)
     /* prettier-ignore */ if (logFlags.aalg) console.log('aalg: fetchAndCacheAccountData-error', elapsed, txid, shardusAddress, type)
   }

--- a/src/state/shardeumState.ts
+++ b/src/state/shardeumState.ts
@@ -411,7 +411,7 @@ export default class ShardeumState implements EVMStateManagerInterface {
 
     if (this._transactionState != null) {
       //side run system on the side for now
-      this._transactionState.putContractStorage(address, key, value)
+      await this._transactionState.putContractStorage(address, key, value)
     }
     return
   }

--- a/src/state/transactionState.ts
+++ b/src/state/transactionState.ts
@@ -554,11 +554,10 @@ export default class TransactionState {
 
     if (this.debugTrace) this.debugTraceLog(`putAccount: addr:${addressString} v:${Utils.safeStringify(accountObj)}`)
 
-    // write to allAccountWrites when checkpointing is enabled
-    // The checkpoint system preserves allAccountWrites in the stack for revert
-    if (ShardeumFlags.CheckpointRevertSupport && this.checkpointCount > 0) {
-      this.allAccountWrites.set(addressString, storedRlp)
-    } else if (this.allAccountWritesStack.length > 0) {
+    //this.allAccountWrites.set(addressString, storedRlp)
+
+    //this.checkpoints[this.checkpoints.length - 1]
+    if (this.allAccountWritesStack.length > 0) {
       const accountWrites = this.allAccountWritesStack[this.allAccountWritesStack.length - 1]
       accountWrites.set(addressString, storedRlp)
     } else {
@@ -1012,8 +1011,8 @@ export default class TransactionState {
     }
 
     //we need checkpoint / revert stack support for accounts so that gas is handled correctly
-    // Save current state to stack before clearing for new changes
-    this.allAccountWritesStack.push(new Map(this.allAccountWrites))
+    //this.allAccountWritesStack.push(this.allAccountWrites)
+    this.allAccountWritesStack.push(new Map<string, Uint8Array>())
 
     // Also checkpoint contract bytecode writes
     this.allContractBytesWritesStack.push(new Map(this.allContractBytesWrites))
@@ -1110,6 +1109,7 @@ export default class TransactionState {
 
       if (this.allAccountWritesStack.length > 0) {
         this.allAccountWrites = this.allAccountWritesStack.pop()
+        this.allAccountWrites.clear()
       } else {
         this.allAccountWrites.clear()
       }

--- a/src/state/transactionState.ts
+++ b/src/state/transactionState.ts
@@ -1065,6 +1065,10 @@ export default class TransactionState {
 
     if (this.checkpointCount > 0) {
       this.checkpointCount--
+    } else {
+      // Safeguard: Prevent negative checkpoint count
+      if (this.debugTrace) this.debugTraceLog(`Warning: Attempted commit with checkpointCount=0, ignoring to prevent negative count`)
+      nestedCountersInstance.countEvent('transactionState', 'commit-at-zero-checkpoint')
     }
     if (this.debugTrace) this.debugTraceLog(`checkpointCount:${this.checkpointCount} commit `)
 
@@ -1098,38 +1102,45 @@ export default class TransactionState {
 
     //we need checkpoint / revert stack support for accounts so that gas is handled correctly
 
-    //the top of the stack becomes our base level set of values.
-    //this.allAccountWrites = this.allAccountWritesStack.pop()
-
-    if (this.allAccountWritesStack.length > 0) {
-      this.allAccountWrites = this.allAccountWritesStack.pop()
-      this.allAccountWrites.clear()
-    } else {
-      this.allAccountWrites.clear()
-    }
-
-    // Restore contract bytecode writes from stack
-    if (this.allContractBytesWritesStack.length > 0) {
-      this.allContractBytesWrites = this.allContractBytesWritesStack.pop()
-    } else {
-      this.allContractBytesWrites.clear()
-    }
-
-    if (this.allContractBytesWritesByAddressStack.length > 0) {
-      this.allContractBytesWritesByAddress = this.allContractBytesWritesByAddressStack.pop()
-    } else {
-      this.allContractBytesWritesByAddress.clear()
-    }
-
-    // Restore contract storage writes from stack
-    if (this.allContractStorageWritesStack.length > 0) {
-      this.allContractStorageWrites = this.allContractStorageWritesStack.pop()
-    } else {
-      this.allContractStorageWrites.clear()
-    }
-
+    // Only perform revert operations if we have a checkpoint to revert to
     if (this.checkpointCount > 0) {
+      //the top of the stack becomes our base level set of values.
+      //this.allAccountWrites = this.allAccountWritesStack.pop()
+
+      if (this.allAccountWritesStack.length > 0) {
+        this.allAccountWrites = this.allAccountWritesStack.pop()
+        this.allAccountWrites.clear()
+      } else {
+        this.allAccountWrites.clear()
+      }
+
+      // Restore contract bytecode writes from stack
+      if (this.allContractBytesWritesStack.length > 0) {
+        this.allContractBytesWrites = this.allContractBytesWritesStack.pop()
+      } else {
+        this.allContractBytesWrites.clear()
+      }
+
+      if (this.allContractBytesWritesByAddressStack.length > 0) {
+        this.allContractBytesWritesByAddress = this.allContractBytesWritesByAddressStack.pop()
+      } else {
+        this.allContractBytesWritesByAddress.clear()
+      }
+
+      // Restore contract storage writes from stack
+      if (this.allContractStorageWritesStack.length > 0) {
+        this.allContractStorageWrites = this.allContractStorageWritesStack.pop()
+      } else {
+        this.allContractStorageWrites.clear()
+      }
+
       this.checkpointCount--
+    } else {
+      // Safeguard: Prevent negative checkpoint count and skip revert operations
+      if (this.debugTrace) this.debugTraceLog(`Warning: Attempted revert with checkpointCount=0, skipping revert operations to prevent state corruption`)
+      nestedCountersInstance.countEvent('transactionState', `revert-at-zero-checkpoint:${message}`)
+      // Don't clear any state when there's no checkpoint to revert to
+      return
     }
     if (this.debugTrace) this.debugTraceLog(`checkpointCount:${this.checkpointCount} revert `)
     if (this.debugTrace)

--- a/src/state/transactionState.ts
+++ b/src/state/transactionState.ts
@@ -554,10 +554,11 @@ export default class TransactionState {
 
     if (this.debugTrace) this.debugTraceLog(`putAccount: addr:${addressString} v:${Utils.safeStringify(accountObj)}`)
 
-    //this.allAccountWrites.set(addressString, storedRlp)
-
-    //this.checkpoints[this.checkpoints.length - 1]
-    if (this.allAccountWritesStack.length > 0) {
+    // write to allAccountWrites when checkpointing is enabled
+    // The checkpoint system preserves allAccountWrites in the stack for revert
+    if (ShardeumFlags.CheckpointRevertSupport && this.checkpointCount > 0) {
+      this.allAccountWrites.set(addressString, storedRlp)
+    } else if (this.allAccountWritesStack.length > 0) {
       const accountWrites = this.allAccountWritesStack[this.allAccountWritesStack.length - 1]
       accountWrites.set(addressString, storedRlp)
     } else {
@@ -1011,8 +1012,8 @@ export default class TransactionState {
     }
 
     //we need checkpoint / revert stack support for accounts so that gas is handled correctly
-    //this.allAccountWritesStack.push(this.allAccountWrites)
-    this.allAccountWritesStack.push(new Map<string, Uint8Array>())
+    // Save current state to stack before clearing for new changes
+    this.allAccountWritesStack.push(new Map(this.allAccountWrites))
 
     // Also checkpoint contract bytecode writes
     this.allContractBytesWritesStack.push(new Map(this.allContractBytesWrites))
@@ -1109,7 +1110,6 @@ export default class TransactionState {
 
       if (this.allAccountWritesStack.length > 0) {
         this.allAccountWrites = this.allAccountWritesStack.pop()
-        this.allAccountWrites.clear()
       } else {
         this.allAccountWrites.clear()
       }

--- a/src/state/transactionState.ts
+++ b/src/state/transactionState.ts
@@ -103,6 +103,10 @@ export default class TransactionState {
   allContractBytesWrites: Map<string, ContractByteWrite>
   allContractBytesWritesByAddress: Map<string, ContractByteWrite>
 
+  // Stack for contract bytecode checkpointing
+  allContractBytesWritesStack: Map<string, ContractByteWrite>[]
+  allContractBytesWritesByAddressStack: Map<string, ContractByteWrite>[]
+
   // pending contract storage commits
   pendingContractStorageCommits: Map<string, Map<string, Uint8Array>>
   pendingContractBytesCommits: Map<string, Map<string, WrappedEVMAccount>>
@@ -228,6 +232,8 @@ export default class TransactionState {
     this.firstContractBytesReads = new Map()
     this.allContractBytesWrites = new Map()
     this.allContractBytesWritesByAddress = new Map()
+    this.allContractBytesWritesStack = []
+    this.allContractBytesWritesByAddressStack = []
 
     this.pendingContractStorageCommits = new Map()
     this.pendingContractBytesCommits = new Map()
@@ -1004,6 +1010,10 @@ export default class TransactionState {
     //this.allAccountWritesStack.push(this.allAccountWrites)
     this.allAccountWritesStack.push(new Map<string, Uint8Array>())
 
+    // Also checkpoint contract bytecode writes
+    this.allContractBytesWritesStack.push(new Map(this.allContractBytesWrites))
+    this.allContractBytesWritesByAddressStack.push(new Map(this.allContractBytesWritesByAddress))
+
     this.allAccountWrites = new Map()
 
     //this.canCommit = true
@@ -1085,10 +1095,22 @@ export default class TransactionState {
     this.allAccountWrites = this.allAccountWritesStack.pop()
     this.allAccountWrites.clear()
 
+    // Restore contract bytecode writes from stack
+    if (this.allContractBytesWritesStack.length > 0) {
+      this.allContractBytesWrites = this.allContractBytesWritesStack.pop()
+    } else {
+      this.allContractBytesWrites.clear()
+    }
+
+    if (this.allContractBytesWritesByAddressStack.length > 0) {
+      this.allContractBytesWritesByAddress = this.allContractBytesWritesByAddressStack.pop()
+    } else {
+      this.allContractBytesWritesByAddress.clear()
+    }
+
     //other saved values do not need a stack and are simply cleared:
     //this.allAccountWrites.clear()
     this.allContractStorageWrites.clear()
-    this.allContractBytesWritesByAddress.clear()
 
     this.checkpointCount--
     if (this.debugTrace) this.debugTraceLog(`checkpointCount:${this.checkpointCount} revert `)

--- a/src/state/transactionState.ts
+++ b/src/state/transactionState.ts
@@ -554,10 +554,10 @@ export default class TransactionState {
 
     if (this.debugTrace) this.debugTraceLog(`putAccount: addr:${addressString} v:${Utils.safeStringify(accountObj)}`)
 
-    //this.allAccountWrites.set(addressString, storedRlp)
-
-    //this.checkpoints[this.checkpoints.length - 1]
-    if (this.allAccountWritesStack.length > 0) {
+    // When CheckpointRevertSupport is enabled, always write to allAccountWrites
+    if (ShardeumFlags.CheckpointRevertSupport) {
+      this.allAccountWrites.set(addressString, storedRlp)
+    } else if (this.allAccountWritesStack.length > 0) {
       const accountWrites = this.allAccountWritesStack[this.allAccountWritesStack.length - 1]
       accountWrites.set(addressString, storedRlp)
     } else {
@@ -1011,8 +1011,8 @@ export default class TransactionState {
     }
 
     //we need checkpoint / revert stack support for accounts so that gas is handled correctly
-    //this.allAccountWritesStack.push(this.allAccountWrites)
-    this.allAccountWritesStack.push(new Map<string, Uint8Array>())
+    this.allAccountWritesStack.push(new Map(this.allAccountWrites))
+    //this.allAccountWritesStack.push(new Map<string, Uint8Array>())
 
     // Also checkpoint contract bytecode writes
     this.allContractBytesWritesStack.push(new Map(this.allContractBytesWrites))
@@ -1084,6 +1084,15 @@ export default class TransactionState {
     } else if (this.checkpointCount === 0) {
       // if (this.debugTrace) console.log('commit: allAccountWritesStack', this.logAccountWritesStack(this.allAccountWritesStack))
       this.flushToCommittedValues()
+      
+      // Move allAccountWrites to committedAccountWrites when checkpointCount is 0
+      // This handles the case where CheckpointRevertSupport is enabled but no checkpoints are active
+      if (ShardeumFlags.CheckpointRevertSupport) {
+        for (const [key, value] of this.allAccountWrites.entries()) {
+          this.committedAccountWrites.set(key, value)
+        }
+        this.allAccountWrites.clear()
+      }
     }
 
     //not 100% sure if we should do this...
@@ -1109,7 +1118,6 @@ export default class TransactionState {
 
       if (this.allAccountWritesStack.length > 0) {
         this.allAccountWrites = this.allAccountWritesStack.pop()
-        this.allAccountWrites.clear()
       } else {
         this.allAccountWrites.clear()
       }
@@ -1200,11 +1208,13 @@ export default class TransactionState {
     } else {
       // this version commits one layer at a time /////
       const accountWrites = this.allAccountWritesStack.pop()
-      for (const [key, value] of accountWrites.entries()) {
-        //if our flattened list does not have the value yet
-        if (this.committedAccountWrites.has(key) === false) {
-          //then flatten the value from the stack into it
-          this.committedAccountWrites.set(key, value)
+      if (accountWrites) {
+        for (const [key, value] of accountWrites.entries()) {
+          //if our flattened list does not have the value yet
+          if (this.committedAccountWrites.has(key) === false) {
+            //then flatten the value from the stack into it
+            this.committedAccountWrites.set(key, value)
+          }
         }
       }
     }

--- a/src/state/transactionState.ts
+++ b/src/state/transactionState.ts
@@ -107,6 +107,9 @@ export default class TransactionState {
   allContractBytesWritesStack: Map<string, ContractByteWrite>[]
   allContractBytesWritesByAddressStack: Map<string, ContractByteWrite>[]
 
+  // Stack for contract storage checkpointing
+  allContractStorageWritesStack: Map<string, Map<string, Uint8Array>>[]
+
   // pending contract storage commits
   pendingContractStorageCommits: Map<string, Map<string, Uint8Array>>
   pendingContractBytesCommits: Map<string, Map<string, WrappedEVMAccount>>
@@ -234,6 +237,7 @@ export default class TransactionState {
     this.allContractBytesWritesByAddress = new Map()
     this.allContractBytesWritesStack = []
     this.allContractBytesWritesByAddressStack = []
+    this.allContractStorageWritesStack = []
 
     this.pendingContractStorageCommits = new Map()
     this.pendingContractBytesCommits = new Map()
@@ -1014,6 +1018,9 @@ export default class TransactionState {
     this.allContractBytesWritesStack.push(new Map(this.allContractBytesWrites))
     this.allContractBytesWritesByAddressStack.push(new Map(this.allContractBytesWritesByAddress))
 
+    // Also checkpoint contract storage writes
+    this.allContractStorageWritesStack.push(new Map(this.allContractStorageWrites))
+
     this.allAccountWrites = new Map()
 
     //this.canCommit = true
@@ -1056,7 +1063,9 @@ export default class TransactionState {
     //I think it is best to clear this. this will allow the newest values to get in
     //this does make some assumptions about how many times commit is called though..
 
-    this.checkpointCount--
+    if (this.checkpointCount > 0) {
+      this.checkpointCount--
+    }
     if (this.debugTrace) this.debugTraceLog(`checkpointCount:${this.checkpointCount} commit `)
 
     if (this.checkpointCount > 0) {
@@ -1092,8 +1101,12 @@ export default class TransactionState {
     //the top of the stack becomes our base level set of values.
     //this.allAccountWrites = this.allAccountWritesStack.pop()
 
-    this.allAccountWrites = this.allAccountWritesStack.pop()
-    this.allAccountWrites.clear()
+    if (this.allAccountWritesStack.length > 0) {
+      this.allAccountWrites = this.allAccountWritesStack.pop()
+      this.allAccountWrites.clear()
+    } else {
+      this.allAccountWrites.clear()
+    }
 
     // Restore contract bytecode writes from stack
     if (this.allContractBytesWritesStack.length > 0) {
@@ -1108,11 +1121,16 @@ export default class TransactionState {
       this.allContractBytesWritesByAddress.clear()
     }
 
-    //other saved values do not need a stack and are simply cleared:
-    //this.allAccountWrites.clear()
-    this.allContractStorageWrites.clear()
+    // Restore contract storage writes from stack
+    if (this.allContractStorageWritesStack.length > 0) {
+      this.allContractStorageWrites = this.allContractStorageWritesStack.pop()
+    } else {
+      this.allContractStorageWrites.clear()
+    }
 
-    this.checkpointCount--
+    if (this.checkpointCount > 0) {
+      this.checkpointCount--
+    }
     if (this.debugTrace) this.debugTraceLog(`checkpointCount:${this.checkpointCount} revert `)
     if (this.debugTrace)
       console.log('revert: allAccountWritesStack', this.logAccountWritesStack(this.allAccountWritesStack))

--- a/test/unit/src/state/revertVulnerability.test.ts
+++ b/test/unit/src/state/revertVulnerability.test.ts
@@ -1,0 +1,259 @@
+import { Account, Address } from '@ethereumjs/util'
+import TransactionState, { RunType } from '../../../../src/state/transactionState'
+import { ShardeumFlags } from '../../../../src/shardeum/shardeumFlags'
+import { Trie } from '@ethereumjs/trie'
+
+// Mock dependencies
+jest.mock('../../../../src/index', () => ({
+  shardeumGetTime: jest.fn(() => Date.now()),
+  isArchiverMode: jest.fn(() => false),
+}))
+
+jest.mock('../../../../src/storage/accountStorage', () => ({
+  getAccount: jest.fn().mockResolvedValue(null),
+  cachedNetworkAccount: null,
+}))
+
+/**
+ * CRITICAL VULNERABILITY DEMONSTRATION
+ *
+ * These tests demonstrate the severe security flaw in the current checkpoint/revert
+ * implementation where a revert() call in an inner scope completely clears ALL
+ * contract storage and bytecode changes, including those from parent scopes.
+ *
+ * This vulnerability could lead to:
+ * 1. Loss of user funds in DeFi protocols
+ * 2. State corruption attacks
+ * 3. Manipulation of critical contract data
+ * 4. Bypassing access controls and invariants
+ */
+describe('TransactionState - Critical Revert Vulnerability Demo', () => {
+  let transactionState: TransactionState
+  let mockCallbacks: any
+  let mockShardeumState: any
+
+  beforeEach(() => {
+    ShardeumFlags.CheckpointRevertSupport = true
+
+    mockCallbacks = {
+      storageMiss: jest.fn().mockResolvedValue(false),
+      contractStorageMiss: jest.fn().mockResolvedValue(false),
+      accountInvolved: jest.fn().mockReturnValue(true),
+      contractStorageInvolved: jest.fn().mockReturnValue(true),
+      tryGetRemoteAccountCB: jest.fn().mockResolvedValue(undefined),
+      monitorEventCB: jest.fn(),
+    }
+
+    mockShardeumState = {}
+
+    transactionState = new TransactionState()
+    transactionState.initData(mockShardeumState, mockCallbacks, 'tx123', null, null, RunType.Apply)
+  })
+
+  describe('FIX VERIFICATION: DeFi Protocol Protection', () => {
+    test('FIX: Revert correctly preserves checkpoint state for both accounts and storage', async () => {
+      // Simulate a DeFi lending protocol with SHM balances and token operations
+      const userAccount = Address.fromString('0x1111111111111111111111111111111111111111')
+      const lendingContract = Address.fromString('0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF')
+      const tokenBalanceKey = new Uint8Array([0x01, ...userAccount.toBytes()]) // User's token balance storage key
+      const contractReservesKey = new Uint8Array([0x02])
+      const attackerKey = new Uint8Array([0x03])
+
+      // 1. Set up initial SHM balances
+      const initialUserShmBalance = BigInt('5000000000000000000') // 5 SHM in wei
+      const initialContractShmBalance = BigInt('10000000000000000000') // 10 SHM in wei
+
+      // Create user account with SHM balance
+      const userEVMAccount = new Account(BigInt(0), initialUserShmBalance)
+      await transactionState.putAccount(userAccount, userEVMAccount)
+
+      // Create contract account with SHM balance
+      const contractEVMAccount = new Account(BigInt(0), initialContractShmBalance)
+      await transactionState.putAccount(lendingContract, contractEVMAccount)
+
+      // Verify initial SHM balances
+      const initialUserAccount = await transactionState.getAccount(new Trie(), userAccount, false, false)
+      const initialContractAccount = await transactionState.getAccount(new Trie(), lendingContract, false, false)
+      expect(initialUserAccount?.balance).toBe(initialUserShmBalance)
+      expect(initialContractAccount?.balance).toBe(initialContractShmBalance)
+      console.log(
+        '✓ Initial SHM balances set - User:',
+        initialUserShmBalance.toString(),
+        'Contract:',
+        initialContractShmBalance.toString()
+      )
+
+      // 2. Contract modifies SHM balances and issues tokens
+      const userShmDeduction = BigInt('1000000000000000000') // Deduct 1 SHM from user
+      const contractShmAddition = BigInt('1000000000000000000') // Add 1 SHM to contract
+      const tokenAmount = new Uint8Array([0x03, 0xe8]) // Issue 1000 tokens to user
+
+      // Modify user SHM balance (simulate payment to contract)
+      const updatedUserAccount = new Account(BigInt(0), initialUserShmBalance - userShmDeduction)
+      await transactionState.putAccount(userAccount, updatedUserAccount)
+
+      // Modify contract SHM balance (receive payment)
+      const updatedContractAccount = new Account(BigInt(0), initialContractShmBalance + contractShmAddition)
+      await transactionState.putAccount(lendingContract, updatedContractAccount)
+
+      // Issue tokens to user (store in contract storage)
+      await transactionState.putContractStorage(lendingContract, tokenBalanceKey, tokenAmount)
+      await transactionState.putContractStorage(lendingContract, contractReservesKey, new Uint8Array([0x27, 0x10]))
+
+      // Verify balances and token issuance
+      const modifiedUserAccount = await transactionState.getAccount(new Trie(), userAccount, false, false)
+      const modifiedContractAccount = await transactionState.getAccount(new Trie(), lendingContract, false, false)
+      const userTokenBalance = await transactionState.getContractStorage(
+        null,
+        lendingContract,
+        tokenBalanceKey,
+        false,
+        false
+      )
+
+      expect(modifiedUserAccount?.balance).toBe(BigInt('4000000000000000000'))
+      expect(modifiedContractAccount?.balance).toBe(BigInt('11000000000000000000'))
+      expect(userTokenBalance).toEqual(tokenAmount)
+      console.log(
+        '✓ Balances modified and tokens issued - User SHM:',
+        modifiedUserAccount?.balance.toString(),
+        'User Tokens:',
+        userTokenBalance
+      )
+
+      // 3. CREATE CHECKPOINT
+      transactionState.checkpoint()
+      console.log('✓ Checkpoint created after balance modifications and token issuance')
+
+      // 4. Perform additional operations that will be reverted
+      await transactionState.putContractStorage(lendingContract, attackerKey, new Uint8Array([0xff]))
+
+      // Modify balances again (these should be reverted)
+      const tempUserAccount = new Account(BigInt(0), BigInt('2000000000000000000'))
+      const tempContractAccount = new Account(BigInt(0), BigInt('15000000000000000000'))
+      await transactionState.putAccount(userAccount, tempUserAccount)
+      await transactionState.putAccount(lendingContract, tempContractAccount)
+
+      // 5. REVERT IS CALLED
+      transactionState.revert('operation failed - testing revert behavior')
+
+      // 6. VERIFY RESULTS: SHM balances should be restored, but tokens should be lost due to vulnerability
+      const finalUserAccount = await transactionState.getAccount(new Trie(), userAccount, false, false)
+      const finalContractAccount = await transactionState.getAccount(new Trie(), lendingContract, false, false)
+      const finalUserTokenBalance = await transactionState.getContractStorage(
+        null,
+        lendingContract,
+        tokenBalanceKey,
+        false,
+        false
+      )
+      const finalContractReserves = await transactionState.getContractStorage(
+        null,
+        lendingContract,
+        contractReservesKey,
+        false,
+        false
+      )
+
+      console.log('🔍 RESULTS AFTER REVERT:')
+      console.log('   User SHM Balance - Expected: 4000000000000000000, Actual:', finalUserAccount?.balance.toString())
+      console.log(
+        '   Contract SHM Balance - Expected: 11000000000000000000, Actual:',
+        finalContractAccount?.balance.toString()
+      )
+      console.log('   User Token Balance - Expected: [3,232], Actual:', Array.from(finalUserTokenBalance || []))
+      console.log('   Token Balance Lost:', finalUserTokenBalance?.length === 0)
+
+      // SHM balances should be correctly restored to checkpoint state
+      expect(finalUserAccount?.balance).toBe(BigInt('4000000000000000000'))
+      expect(finalContractAccount?.balance).toBe(BigInt('11000000000000000000'))
+
+      // WITH FIX: Token balances should now be correctly preserved after revert
+      expect(finalUserTokenBalance).toEqual(tokenAmount) // FIX VERIFIED: Token balance preserved!
+      expect(finalContractReserves).toEqual(new Uint8Array([0x27, 0x10])) // FIX VERIFIED: Reserves preserved!
+
+      console.log('✅ Fix Verification Complete:')
+      console.log('   - SHM balances correctly restored to checkpoint state')
+      console.log('   - Token balances correctly preserved (no longer lost)')
+      console.log('   - Contract storage properly maintained across revert')
+    })
+
+    test('SECURITY: Multiple reverts should not force checkpoint count negative', async () => {
+      const testAccount = Address.fromString('0x1234567890123456789012345678901234567890')
+      const storageKey = new Uint8Array([0x01])
+      
+      // Set initial state WITHOUT checkpoint (this is the committed state)
+      const initialAccount = new Account(BigInt(0), BigInt('1000000000000000000'))
+      await transactionState.putAccount(testAccount, initialAccount)
+      await transactionState.putContractStorage(testAccount, storageKey, new Uint8Array([0x10]))
+      
+      console.log('✓ Initial state set')
+      
+      // Create a checkpoint
+      transactionState.checkpoint()
+      console.log('✓ Checkpoint 1 created')
+      
+      // Modify state after checkpoint
+      const modifiedAccount = new Account(BigInt(0), BigInt('2000000000000000000'))
+      await transactionState.putAccount(testAccount, modifiedAccount)
+      await transactionState.putContractStorage(testAccount, storageKey, new Uint8Array([0x20]))
+      
+      // Verify modified state
+      const beforeRevert = await transactionState.getAccount(new Trie(), testAccount, false, false)
+      const beforeRevertStorage = await transactionState.getContractStorage(null, testAccount, storageKey, false, false)
+      expect(beforeRevert?.balance).toBe(BigInt('2000000000000000000'))
+      expect(beforeRevertStorage).toEqual(new Uint8Array([0x20]))
+      console.log('✓ State modified after checkpoint')
+      
+      // First revert - this should work normally and revert to checkpoint state
+      transactionState.revert('first revert')
+      console.log('✓ First revert completed')
+      
+      // Verify state was reverted to checkpoint state (which should be the initial state)
+      const afterFirstRevert = await transactionState.getAccount(new Trie(), testAccount, false, false)
+      const afterFirstRevertStorage = await transactionState.getContractStorage(null, testAccount, storageKey, false, false)
+      console.log('After first revert - Account balance:', afterFirstRevert?.balance.toString())
+      console.log('After first revert - Storage value:', Array.from(afterFirstRevertStorage || []))
+      
+      // The state should be back to what it was at checkpoint time
+      expect(afterFirstRevert?.balance).toBe(BigInt('1000000000000000000'))
+      // Note: Due to the current implementation, the storage might not revert correctly
+      // This is the bug we're documenting - storage should be 0x10 but might be different
+      
+      // Now make another change without a checkpoint
+      await transactionState.putContractStorage(testAccount, storageKey, new Uint8Array([0x30]))
+      
+      // VULNERABILITY TEST: Try to revert again without a checkpoint
+      // This should not crash or cause negative checkpoint count
+      console.log('⚠️ Attempting second revert without checkpoint...')
+      
+      // This should be handled gracefully and not change state
+      expect(() => {
+        transactionState.revert('second revert - should be handled safely')
+      }).not.toThrow()
+      
+      // Try multiple reverts to stress test
+      console.log('⚠️ Attempting multiple additional reverts...')
+      for (let i = 0; i < 5; i++) {
+        expect(() => {
+          transactionState.revert(`revert attempt ${i + 3}`)
+        }).not.toThrow()
+      }
+      
+      // Verify state after multiple invalid reverts
+      const finalAccount = await transactionState.getAccount(new Trie(), testAccount, false, false)
+      const finalStorage = await transactionState.getContractStorage(null, testAccount, storageKey, false, false)
+      
+      // Account balance should remain consistent
+      expect(finalAccount?.balance).toBe(BigInt('1000000000000000000'))
+      // Storage should keep the 0x30 value since reverts without checkpoints are now ignored
+      expect(finalStorage).toEqual(new Uint8Array([0x30]))
+      
+      console.log('✅ Security Check Complete:')
+      console.log('   - Multiple reverts handled safely without crashes')
+      console.log('   - Checkpoint count never went negative')
+      console.log('   - Invalid reverts are properly ignored')
+      console.log('   - State remains consistent after invalid operations')
+    })
+  })
+})

--- a/test/unit/src/state/transactionState.test.ts
+++ b/test/unit/src/state/transactionState.test.ts
@@ -302,14 +302,41 @@ describe('TransactionState', () => {
 
       transactionState.putAccount(address1, account1)
 
-      const topStack = transactionState.allAccountWritesStack[transactionState.allAccountWritesStack.length - 1]
-      expect(topStack.has(addressString1)).toBe(true)
+      // When CheckpointRevertSupport is enabled, putAccount writes to allAccountWrites
+      expect(transactionState.allAccountWrites.has(addressString1)).toBe(true)
     })
 
-    test('should add account to firstAccountReads if no checkpoints', () => {
+    test('should add account to allAccountWrites when CheckpointRevertSupport is enabled', () => {
+      transactionState.putAccount(address1, account1)
+
+      // When CheckpointRevertSupport is enabled, putAccount writes to allAccountWrites
+      expect(transactionState.allAccountWrites.has(addressString1)).toBe(true)
+    })
+
+    test('should add account to firstAccountReads when CheckpointRevertSupport is disabled', () => {
+      ShardeumFlags.CheckpointRevertSupport = false
+      
       transactionState.putAccount(address1, account1)
 
       expect(transactionState.firstAccountReads.has(addressString1)).toBe(true)
+      expect(transactionState.allAccountWrites.has(addressString1)).toBe(false)
+      
+      // Reset flag
+      ShardeumFlags.CheckpointRevertSupport = true
+    })
+
+    test('should add account to stack when CheckpointRevertSupport is disabled but stack exists', () => {
+      ShardeumFlags.CheckpointRevertSupport = false
+      transactionState.allAccountWritesStack.push(new Map())
+      
+      transactionState.putAccount(address1, account1)
+
+      const topStack = transactionState.allAccountWritesStack[transactionState.allAccountWritesStack.length - 1]
+      expect(topStack.has(addressString1)).toBe(true)
+      expect(transactionState.firstAccountReads.has(addressString1)).toBe(false)
+      
+      // Reset flag
+      ShardeumFlags.CheckpointRevertSupport = true
     })
 
     test('should ignore virtual 0 address when flag is set', () => {
@@ -318,7 +345,7 @@ describe('TransactionState', () => {
 
       transactionState.putAccount(zeroAddress, account1)
 
-      expect(transactionState.firstAccountReads.has(zeroAddressStr)).toBe(false)
+      expect(transactionState.allAccountWrites.has(zeroAddressStr)).toBe(false)
       ShardeumFlags.Virtual0Address = false
     })
 
@@ -596,18 +623,32 @@ describe('TransactionState', () => {
     })
 
     test('revert should discard checkpoint changes', () => {
+      // Add account1 before first checkpoint
+      transactionState.putAccount(address1, account1)
+      
+      // First checkpoint - saves account1 to stack, clears allAccountWrites
       transactionState.checkpoint()
-      const checkpoint1 = new Map([[addressString1, account1.serialize()]])
-      transactionState.allAccountWritesStack[0] = checkpoint1
-
+      
+      // Add account2 after checkpoint
+      transactionState.putAccount(address2, account2)
+      
+      // Second checkpoint - saves account2 to stack, clears allAccountWrites  
       transactionState.checkpoint()
-      transactionState.allAccountWritesStack[1].set(addressString2, account2.serialize())
+      
+      // Add another account after second checkpoint
+      const address3 = new Address(Buffer.from('0xfedcba9876543210fedcba9876543210fedcba98'.slice(2), 'hex'))
+      const account3 = new Account()
+      account3.balance = BigInt(300)
+      transactionState.putAccount(address3, account3)
 
+      // Revert second checkpoint
       transactionState.revert('test revert')
 
       expect(transactionState.checkpointCount).toBe(1)
       expect(transactionState.allAccountWritesStack.length).toBe(1)
-      expect(transactionState.allAccountWrites.size).toBe(0)
+      // After revert, allAccountWrites should contain account2 from before the second checkpoint
+      expect(transactionState.allAccountWrites.size).toBe(1)
+      expect(transactionState.allAccountWrites.has(addressString2)).toBe(true)
       expect(transactionState.allContractStorageWrites.size).toBe(0)
     })
 


### PR DESCRIPTION
### **User description**
These changes address the following bugs:

- checkpoint() saves allAccountWrite to a stack but does not save the state of contract bytecode.
- revert() partially clears contract bytecode state by clearing allContractBytesWritesByAddress but leaves allContractBytesWrites untouched.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix checkpoint and revert logic for contract bytecode writes

- Add stack-based tracking for contract bytecode write states

- Ensure proper restoration of contract bytecode on revert

- Improve consistency in transaction state management


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transactionState.ts</strong><dd><code>Fix and enhance contract bytecode checkpoint/revert logic</code></dd></summary>
<hr>

src/state/transactionState.ts

<li>Added stack structures for contract bytecode write checkpoints<br> <li> Updated checkpoint method to save contract bytecode write states<br> <li> Updated revert method to restore contract bytecode write states from <br>stack<br> <li> Removed incomplete clearing of contract bytecode writes in revert


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum/pull/596/files#diff-3cd3fb5b521141d7f3cede2fcc72797c2920ee7e8a440029a266bb9dd8808674">+23/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>